### PR TITLE
[sonarqube] allow overriding app fullname

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 4.2.0
+version: 4.2.1
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 4.2.1
+version: 4.3.0
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -11,8 +11,11 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "sonarqube.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "sonarqube.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Allows to override the `fullname` used in various places. Today, a
helper template function determines the format of the name, and it can't
be overridden. This is inconvenient and unwanted in many cases (e.g.
when tooling maps the app name to a hostname—I want
`sonarqube.example.org`, but today I can only get
`sonarqube-sonarqube.example.org`). It's generally better to allow the
fullname to be explicitly overridden if so desired.

See also: helm/charts#20561.