### PR TITLE
charts/sonarqube: fix incorrect variable postgresqlPasswordSecret

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 4.2.0
+version: 4.2.1
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -81,8 +81,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `sonarProperties`                     | Custom `sonar.properties` file                                               | `{}`                                           |
 | `database.type`                       | Set to "mysql" to use mysql database                                         | `postgresql`                                   |
 | `postgresql.enabled`                  | Set to `false` to use external server / mysql database                       | `true`                                         |
+| `postgresql.existingSecret`           | Secret containing the password of the external Postgresql server             | `null`                                         |
 | `postgresql.postgresqlServer`         | Hostname of the external Postgresql server                                   | `null`                                         |
-| `postgresql.postgresqlPasswordSecret` | Secret containing the password of the external Postgresql server             | `null`                                         |
 | `postgresql.postgresqlUsername`       | Postgresql database user                                                     | `sonarUser`                                    |
 | `postgresql.postgresqlPassword`       | Postgresql database password                                                 | `sonarPass`                                    |
 | `postgresql.postgresqlDatabase`       | Postgresql database name                                                     | `sonarDB`                                      |

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -190,7 +190,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- if eq .Values.database.type "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else if .Values.postgresql.postgresqlPasswordSecret }} {{ .Values.postgresql.postgresqlPasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else if .Values.postgresql.existingSecret }} {{ .Values.postgresql.existingSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
                   key: postgresql-password
                   {{- else if eq .Values.database.type "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else if .Values.mysql.mysqlPasswordSecret }} {{ .Values.mysql.mysqlPasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.database.type "postgresql" -}}
 {{- if eq .Values.postgresql.enabled false -}}
-{{- if not .Values.postgresql.postgresqlPasswordSecret -}}
+{{- if not .Values.postgresql.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -201,7 +201,7 @@ postgresql:
   # To use an external secret for the password for an external PostgreSQL
   # instance, set enabled to false and provide the name of the secret on the
   # line below:
-  # postgresqlPasswordSecret: ""
+  # existingSecret: ""
   postgresqlUsername: "sonarUser"
   postgresqlPassword: "sonarPass"
   postgresqlDatabase: "sonarDB"


### PR DESCRIPTION
To use already existing secret to connect PostgreSQL you must
define postgresql.existingSecret

Fixes #26

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>