### PR TITLE
change service, config and secret to use nexus.fullname

### DIFF
--- a/charts/sonatype-nexus/templates/configmap.yaml
+++ b/charts/sonatype-nexus/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "nexus.name" . }}-conf
+  name: {{ template "nexus.fullname" . }}-conf
   labels:
 {{ include "nexus.labels" . | indent 4 }}
 {{- if .Values.nexus.labels }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "nexus.name" . }}
+      app: {{ template "nexus.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
@@ -40,7 +40,7 @@ spec:
 {{ toYaml .Values.nexus.podAnnotations | indent 8}}
     {{- end }}
       labels:
-        app: {{ template "nexus.name" . }}
+        app: {{ template "nexus.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.deployment.initContainers }}
@@ -110,11 +110,11 @@ spec:
               name: {{ template "nexus.fullname" . }}-backup
             {{- if .Values.config.enabled }}
             - mountPath: {{ .Values.config.mountPath }}
-              name: {{ template "nexus.name" . }}-conf
+              name: {{ template "nexus.fullname" . }}-conf
             {{- end }}
             {{- if .Values.secret.enabled }}
             - mountPath: {{ .Values.secret.mountPath }}
-              name: {{ template "nexus.name" . }}-secret
+              name: {{ template "nexus.fullname" . }}-secret
               readOnly: {{ .Values.secret.readOnly }}
             {{- end }}
             {{- if .Values.deployment.additionalVolumeMounts}}
@@ -252,14 +252,14 @@ spec:
           {{- end }}
         {{- end }}
         {{- if .Values.config.enabled }}
-        - name: {{ template "nexus.name" . }}-conf
+        - name: {{ template "nexus.fullname" . }}-conf
           configMap:
-            name: {{ template "nexus.name" . }}-conf
+            name: {{ template "nexus.fullname" . }}-conf
         {{- end }}
         {{- if .Values.secret.enabled }}
-        - name: {{ template "nexus.name" . }}-secret
+        - name: {{ template "nexus.fullname" . }}-secret
           secret:
-            secretName: {{ template "nexus.name" . }}-secret
+            secretName: {{ template "nexus.fullname" . }}-secret
         {{- end }}
         {{- if .Values.deployment.additionalVolumes }}
 {{ toYaml .Values.deployment.additionalVolumes | indent 8 }}

--- a/charts/sonatype-nexus/templates/proxy-svc.yaml
+++ b/charts/sonatype-nexus/templates/proxy-svc.yaml
@@ -38,7 +38,7 @@ spec:
       targetPort: {{ .Values.nexus.nexusPort }}
 {{- end }}
   selector:
-    app: {{ template "nexus.name" . }}
+    app: {{ template "nexus.fullname" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.nexus.service.type }}
   {{- if and (eq .Values.nexus.service.type "ClusterIP") .Values.nexus.service.clusterIP }}

--- a/charts/sonatype-nexus/templates/route.yaml
+++ b/charts/sonatype-nexus/templates/route.yaml
@@ -20,7 +20,7 @@ spec:
 {{- if .Values.service.name }}
     name: {{ .Values.service.name }}
 {{- else }}
-    name: {{ template "nexus.name" . }}-service
+    name: {{ template "nexus.fullname" . }}-service
 {{- end }}
     weight: 100
   wildcardPolicy: None

--- a/charts/sonatype-nexus/templates/secret.yaml
+++ b/charts/sonatype-nexus/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "nexus.name" . }}-secret
+  name: {{ template "nexus.fullname" . }}-secret
   labels:
 {{ include "nexus.labels" . | indent 4 }}
 {{- if .Values.nexus.labels }}

--- a/charts/sonatype-nexus/templates/service.yaml
+++ b/charts/sonatype-nexus/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
 {{- if .Values.service.name }}
   name: {{ .Values.service.name }}
 {{- else }}
-  name: {{ template "nexus.name" . }}-service
+  name: {{ template "nexus.fullname" . }}-service
 {{- end }}
   labels:
 {{ include "nexus.labels" . | indent 4 }}
@@ -27,7 +27,7 @@ spec:
 {{ toYaml . | indent 2 }}
   {{- end }}
   selector:
-    app: {{ template "nexus.name" . }}
+    app: {{ template "nexus.fullname" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.service.type }}
   {{ if .Values.service.loadBalancerSourceRanges }}


### PR DESCRIPTION
The use of nexus.name in service, config and secret prevent to run 2 releases in in the same namspace.
So I use nexus.fullname that contain the release name