### PR TITLE
Add env to specify an account key to access to the backup GCS bucket

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.25.0
+version: 1.26.0
 appVersion: 3.20.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -115,7 +115,8 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexusBackup.imageName`                     | Nexus backup image                  | `quay.io/travelaudience/docker-nexus-backup` |
 | `nexusBackup.imageTag`                      | Nexus backup image version          | `1.5.0`                                 |
 | `nexusBackup.imagePullPolicy`               | Backup image pull policy            | `IfNotPresent`                          |
-| `nexusBackup.env.targetBucket`              | Required if `nexusBackup` is enabled. Google Cloud Storage bucker for backups format `gs://BACKUP_BUCKET`  | `nil`  |
+| `nexusBackup.env.targetBucket`              | Required if `nexusBackup` is enabled. Google Cloud Storage bucket for backups format `gs://BACKUP_BUCKET`  | `nil`  |
+| `nexusBackup.env.serviceAccountKeyPath`     | Required if `serviceAccountKeyPath` is enabled. Contain the path of the file is define in `secret.data` | `nil`  |
 | `nexusBackup.nexusAdminPassword`            | Nexus admin password used by the backup container to access Nexus API. This password should match the one that gets chosen by the user to replace the default admin password after the first login  | `admin123`                |
 | `nexusBackup.persistence.enabled`           | Create a volume for backing Nexus configuration  | `true`                     |
 | `nexusBackup.persistence.accessMode`        | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                         |

--- a/charts/sonatype-nexus/templates/configmap.yaml
+++ b/charts/sonatype-nexus/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "nexus.name" . }}-conf
+  name: {{ template "nexus.fullname" . }}-conf
   labels:
 {{ include "nexus.labels" . | indent 4 }}
 {{- if .Values.nexus.labels }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "nexus.name" . }}
+      app: {{ template "nexus.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
@@ -40,7 +40,7 @@ spec:
 {{ toYaml .Values.nexus.podAnnotations | indent 8}}
     {{- end }}
       labels:
-        app: {{ template "nexus.name" . }}
+        app: {{ template "nexus.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.deployment.initContainers }}
@@ -110,11 +110,11 @@ spec:
               name: {{ template "nexus.fullname" . }}-backup
             {{- if .Values.config.enabled }}
             - mountPath: {{ .Values.config.mountPath }}
-              name: {{ template "nexus.name" . }}-conf
+              name: {{ template "nexus.fullname" . }}-conf
             {{- end }}
             {{- if .Values.secret.enabled }}
             - mountPath: {{ .Values.secret.mountPath }}
-              name: {{ template "nexus.name" . }}-secret
+              name: {{ template "nexus.fullname" . }}-secret
               readOnly: {{ .Values.secret.readOnly }}
             {{- end }}
             {{- if .Values.deployment.additionalVolumeMounts}}
@@ -252,14 +252,14 @@ spec:
           {{- end }}
         {{- end }}
         {{- if .Values.config.enabled }}
-        - name: {{ template "nexus.name" . }}-conf
+        - name: {{ template "nexus.fullname" . }}-conf
           configMap:
-            name: {{ template "nexus.name" . }}-conf
+            name: {{ template "nexus.fullname" . }}-conf
         {{- end }}
         {{- if .Values.secret.enabled }}
-        - name: {{ template "nexus.name" . }}-secret
+        - name: {{ template "nexus.fullname" . }}-secret
           secret:
-            secretName: {{ template "nexus.name" . }}-secret
+            secretName: {{ template "nexus.fullname" . }}-secret
         {{- end }}
         {{- if .Values.deployment.additionalVolumes }}
 {{ toYaml .Values.deployment.additionalVolumes | indent 8 }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -1,21 +1,21 @@
 {{- if .Values.statefulset.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
-{{- else }}
+  {{- else }}
 apiVersion: apps/v1
 kind: Deployment
-{{- end }}
+  {{- end }}
 metadata:
   name: {{ template "nexus.fullname" . }}
   labels:
-{{ include "nexus.labels" . | indent 4 }}
-{{- if .Values.nexus.labels }}
-{{ toYaml .Values.nexus.labels | indent 4 }}
-{{- end }}
-{{- if .Values.deployment.annotations }}
+  {{ include "nexus.labels" . | indent 4 }}
+  {{- if .Values.nexus.labels }}
+  {{ toYaml .Values.nexus.labels | indent 4 }}
+  {{- end }}
+  {{- if .Values.deployment.annotations }}
   annotations:
-{{ toYaml .Values.deployment.annotations | indent 4 }}
-{{- end }}
+  {{ toYaml .Values.deployment.annotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.statefulset.enabled }}
@@ -27,7 +27,7 @@ spec:
   {{- end }}
   {{- if .Values.deploymentStrategy }}
   strategy:
-{{ toYaml .Values.deploymentStrategy | indent 4 }}
+  {{ toYaml .Values.deploymentStrategy | indent 4 }}
   {{- end }}
   selector:
     matchLabels:
@@ -35,25 +35,25 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-    {{- if .Values.nexus.podAnnotations }}
+      {{- if .Values.nexus.podAnnotations }}
       annotations:
-{{ toYaml .Values.nexus.podAnnotations | indent 8}}
-    {{- end }}
+      {{ toYaml .Values.nexus.podAnnotations | indent 8}}
+      {{- end }}
       labels:
         app: {{ template "nexus.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.deployment.initContainers }}
       initContainers:
-{{ toYaml .Values.deployment.initContainers | indent 6 }}
+      {{ toYaml .Values.deployment.initContainers | indent 6 }}
       {{- end }}
       {{- if .Values.nexus.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nexus.nodeSelector | indent 8 }}
+      {{ toYaml .Values.nexus.nodeSelector | indent 8 }}
       {{- end }}
       {{- if .Values.nexus.hostAliases }}
       hostAliases:
-{{ toYaml .Values.nexus.hostAliases | indent 8 }}
+      {{ toYaml .Values.nexus.hostAliases | indent 8 }}
       {{- end }}
       {{- if .Values.nexus.imagePullSecret }}
       imagePullSecrets:
@@ -75,9 +75,9 @@ spec:
                 command: {{ .Values.deployment.postStart.command }}
           {{- end }}
           env:
-{{ toYaml .Values.nexus.env | indent 12 }}
+          {{ toYaml .Values.nexus.env | indent 12 }}
           resources:
-{{ toYaml .Values.nexus.resources | indent 12 }}
+          {{ toYaml .Values.nexus.resources | indent 12 }}
           ports:
             - containerPort: {{ .Values.nexus.dockerPort }}
               name: nexus-docker-g
@@ -92,7 +92,7 @@ spec:
             failureThreshold: {{ .Values.nexus.livenessProbe.failureThreshold }}
             {{- if .Values.nexus.livenessProbe.timeoutSeconds }}
             timeoutSeconds: {{ .Values.nexus.livenessProbe.timeoutSeconds }}
-            {{- end }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: {{ .Values.nexus.readinessProbe.path }}
@@ -102,7 +102,7 @@ spec:
             failureThreshold: {{ .Values.nexus.readinessProbe.failureThreshold }}
             {{- if .Values.nexus.readinessProbe.timeoutSeconds }}
             timeoutSeconds: {{ .Values.nexus.readinessProbe.timeoutSeconds }}
-            {{- end }}
+          {{- end }}
           volumeMounts:
             - mountPath: /nexus-data
               name: {{ template "nexus.fullname" . }}-data
@@ -118,13 +118,13 @@ spec:
               readOnly: {{ .Values.secret.readOnly }}
             {{- end }}
             {{- if .Values.deployment.additionalVolumeMounts}}
-{{ toYaml .Values.deployment.additionalVolumeMounts | indent 12 }}
-            {{- end }}
-          {{- if .Values.nexusProxy.enabled }}
+            {{ toYaml .Values.deployment.additionalVolumeMounts | indent 12 }}
+          {{- end }}
+        {{- if .Values.nexusProxy.enabled }}
         - name: nexus-proxy
           image: {{ .Values.nexusProxy.imageName }}:{{ .Values.nexusProxy.imageTag }}
           resources:
-{{ toYaml .Values.nexusProxy.resources | indent 12 }}
+          {{ toYaml .Values.nexusProxy.resources | indent 12 }}
           imagePullPolicy: {{ .Values.nexusProxy.imagePullPolicy }}
           env:
             - name: ALLOWED_USER_AGENTS_ON_ROOT_REGEX
@@ -169,7 +169,7 @@ spec:
               value: "86400000"
             - name: JWT_REQUIRES_MEMBERSHIP_VERIFICATION
               value: {{ .Values.nexusProxy.env.requiredMembershipVerification | quote }}
-            {{- end }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.nexusProxy.targetPort }}
               name: nexus-proxy
@@ -179,13 +179,13 @@ spec:
               name: {{ template "nexus.proxy-ks.name" . }}
               readOnly: true
           {{- end }}
-          {{- end }}
+        {{- end }}
         {{- if .Values.nexusBackup.enabled }}
         - name: nexus-backup
           image: {{ .Values.nexusBackup.imageName }}:{{ .Values.nexusBackup.imageTag }}
           imagePullPolicy: {{ .Values.nexusBackup.imagePullPolicy }}
           resources:
-{{ toYaml .Values.nexusBackup.resources | indent 12 }}
+          {{ toYaml .Values.nexusBackup.resources | indent 12 }}
           env:
             - name: NEXUS_AUTHORIZATION
               valueFrom:
@@ -213,13 +213,18 @@ spec:
               name: {{ template "nexus.fullname" . }}-data
             - mountPath: /nexus-data/backup
               name: {{ template "nexus.fullname" . }}-backup
+            {{- if .Values.secret.enabled }}
+            - mountPath: {{ .Values.secret.mountPath }}
+              name: {{ template "nexus.fullname" . }}-secret
+              readOnly: {{ .Values.secret.readOnly }}
+        {{- end }}
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
-{{ toYaml .Values.deployment.additionalContainers | indent 8 }}
-        {{- end }}
+        {{ toYaml .Values.deployment.additionalContainers | indent 8 }}
+      {{- end }}
       {{- if .Values.nexus.securityContext }}
       securityContext:
-{{ toYaml .Values.nexus.securityContext | indent 8 }}
+      {{ toYaml .Values.nexus.securityContext | indent 8 }}
       {{- end }}
       volumes:
         {{- if .Values.nexusProxy.env.cloudIamAuthEnabled }}
@@ -244,14 +249,14 @@ spec:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" (include "nexus.fullname" .) "data") }}
           {{- else }}
           emptyDir: {}
-          {{- end }}
+        {{- end }}
         - name: {{ template "nexus.fullname" . }}-backup
           {{- if and .Values.nexusBackup.enabled (.Values.nexusBackup.persistence.enabled) }}
           persistentVolumeClaim:
             claimName: {{ .Values.nexusBackup.persistence.existingClaim | default (printf "%s-%s" (include "nexus.fullname" .) "backup") }}
           {{- else }}
           emptyDir: {}
-          {{- end }}
+        {{- end }}
         {{- end }}
         {{- if .Values.config.enabled }}
         - name: {{ template "nexus.fullname" . }}-conf
@@ -264,26 +269,26 @@ spec:
             secretName: {{ template "nexus.fullname" . }}-secret
         {{- end }}
         {{- if .Values.deployment.additionalVolumes }}
-{{ toYaml .Values.deployment.additionalVolumes | indent 8 }}
-        {{- end }}
-    {{- with .Values.tolerations }}
+        {{ toYaml .Values.deployment.additionalVolumes | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+    {{ toYaml . | indent 8 }}
+  {{- end }}
 
 
-## create pvc in case of statefulsets
+  ## create pvc in case of statefulsets
   {{- if .Values.statefulset.enabled }}
   volumeClaimTemplates:
     {{- if .Values.persistence.enabled }}
     - metadata:
         name: {{ template "nexus.fullname" . }}-data
         labels:
-{{ include "nexus.labels" . | indent 10 }}
+        {{ include "nexus.labels" . | indent 10 }}
         {{- if .Values.persistence.annotations }}
         annotations:
-{{ toYaml .Values.persistence.annotations | indent 10 }}
-        {{- end }}
+        {{ toYaml .Values.persistence.annotations | indent 10 }}
+      {{- end }}
       spec:
         accessModes:
           - {{ .Values.persistence.accessMode | quote }}
@@ -296,18 +301,18 @@ spec:
         {{- else }}
         storageClassName: "{{ .Values.persistence.storageClass }}"
         {{- end }}
-        {{- end }}
+    {{- end }}
     {{- end }}
 
     {{- if and .Values.nexusBackup.enabled (.Values.nexusBackup.persistence.enabled) }}
     - metadata:
         name: {{ template "nexus.fullname" . }}-backup
         labels:
-{{ include "nexus.labels" . | indent 10 }}
+        {{ include "nexus.labels" . | indent 10 }}
         {{- if .Values.nexusBackup.persistence.annotations }}
         annotations:
-{{ toYaml .Values.nexusBackup.persistence.annotations | indent 10 }}
-        {{- end }}
+        {{ toYaml .Values.nexusBackup.persistence.annotations | indent 10 }}
+      {{- end }}
       spec:
         accessModes:
           - {{ .Values.nexusBackup.persistence.accessMode }}
@@ -320,6 +325,6 @@ spec:
         {{- else }}
         storageClassName: "{{ .Values.nexusBackup.persistence.storageClass }}"
         {{- end }}
-        {{- end }}
     {{- end }}
+  {{- end }}
   {{- end }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -202,6 +202,8 @@ spec:
               value: "maven-central maven-public maven-releases maven-snapshots"
             - name: TARGET_BUCKET
               value: {{ .Values.nexusBackup.env.targetBucket | quote }}
+            - name: CLOUD_IAM_SERVICE_ACCOUNT_KEY_PATH
+              value: {{ .Values.nexusBackup.env.serviceAccountKeyPath | quote }}
             - name: GRACE_PERIOD
               value: "60"
             - name: TRIGGER_FILE

--- a/charts/sonatype-nexus/templates/proxy-svc.yaml
+++ b/charts/sonatype-nexus/templates/proxy-svc.yaml
@@ -38,7 +38,7 @@ spec:
       targetPort: {{ .Values.nexus.nexusPort }}
 {{- end }}
   selector:
-    app: {{ template "nexus.name" . }}
+    app: {{ template "nexus.fullname" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.nexus.service.type }}
   {{- if and (eq .Values.nexus.service.type "ClusterIP") .Values.nexus.service.clusterIP }}

--- a/charts/sonatype-nexus/templates/route.yaml
+++ b/charts/sonatype-nexus/templates/route.yaml
@@ -20,7 +20,7 @@ spec:
 {{- if .Values.service.name }}
     name: {{ .Values.service.name }}
 {{- else }}
-    name: {{ template "nexus.name" . }}-service
+    name: {{ template "nexus.fullname" . }}-service
 {{- end }}
     weight: 100
   wildcardPolicy: None

--- a/charts/sonatype-nexus/templates/secret.yaml
+++ b/charts/sonatype-nexus/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "nexus.name" . }}-secret
+  name: {{ template "nexus.fullname" . }}-secret
   labels:
 {{ include "nexus.labels" . | indent 4 }}
 {{- if .Values.nexus.labels }}

--- a/charts/sonatype-nexus/templates/service.yaml
+++ b/charts/sonatype-nexus/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
 {{- if .Values.service.name }}
   name: {{ .Values.service.name }}
 {{- else }}
-  name: {{ template "nexus.name" . }}-service
+  name: {{ template "nexus.fullname" . }}-service
 {{- end }}
   labels:
 {{ include "nexus.labels" . | indent 4 }}
@@ -27,7 +27,7 @@ spec:
 {{ toYaml . | indent 2 }}
   {{- end }}
   selector:
-    app: {{ template "nexus.name" . }}
+    app: {{ template "nexus.fullname" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.service.type }}
   {{ if .Values.service.loadBalancerSourceRanges }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -140,6 +140,10 @@ nexusBackup:
   imagePullPolicy: IfNotPresent
   env:
     targetBucket:
+    ## Cloud IAM service account key path
+    ## the name of the file is define in secret.data
+    # serviceAccountKeyPath: "/etc/secret-volume/account-key"
+    serviceAccountKeyPath: 
   nexusAdminPassword: "admin123"
   persistence:
     enabled: true
@@ -226,6 +230,8 @@ secret:
   mountPath: /etc/secret-volume
   readOnly: true
   data:
+    ## Service account key file. See nexusBackup.env.serviceAccountKeyPath
+    # account-key: "Insert here the content of the service account key encoded in base64."
 
 # # To use an additional service, set enable to true
 service:


### PR DESCRIPTION
add env CLOUD_IAM_SERVICE_ACCOUNT_KEY_PATH to specify an account key to access to the backup GCS bucket.