### PR TITLE
charts/sonarqube: fix incorrect variable mysqlPasswordSecret

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 4.3.1
+version: 4.3.2
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -88,8 +88,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `postgresql.postgresqlDatabase`       | Postgresql database name                                                     | `sonarDB`                                      |
 | `postgresql.service.port`             | Postgresql port                                                              | `5432`                                         |
 | `mysql.enabled`                       | Set to `false` to use external server / postgresql database                  | `false`                                        |
+| `mysql.existingSecret`                | Secret containing the password of the external Mysql server                  | `null`                                         |
 | `mysql.mysqlServer`                   | Hostname of the external Mysql server                                        | `null`                                         |
-| `mysql.mysqlPasswordSecret`           | Secret containing the password of the external Mysql server                  | `null`                                         |
 | `mysql.mysqlUser`                     | Mysql database user                                                          | `sonarUser`                                    |
 | `mysql.mysqlPassword`                 | Mysql database password                                                      | `sonarPass`                                    |
 | `mysql.mysqlDatabase`                 | Mysql database name                                                          | `sonarDB`                                      |

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -193,7 +193,7 @@ spec:
                   name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else if .Values.postgresql.existingSecret }} {{ .Values.postgresql.existingSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
                   key: postgresql-password
                   {{- else if eq .Values.database.type "mysql" }}
-                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else if .Values.mysql.mysqlPasswordSecret }} {{ .Values.mysql.mysqlPasswordSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
+                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else if .Values.mysql.existingSecret }} {{ .Values.mysql.existingSecret }} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
                   key: mysql-password
                   {{- end }}
             - name: SONARQUBE_JDBC_URL

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -18,7 +18,7 @@ data:
 {{- end -}}
 {{- if eq .Values.database.type "mysql" -}}
 {{- if eq .Values.mysql.enabled false -}}
-{{- if not .Values.mysql.mysqlPasswordSecret -}}
+{{- if not .Values.mysql.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -220,7 +220,7 @@ mysql:
   # mysqlServer: ""
   # To use an external secret for the password for an external mySQL instance,
   # set enabled to false and provide the name of the secret on the line below:
-  # mysqlPasswordSecret: ""
+  # existingSecret: ""
   mysqlUser: "sonarUser"
   mysqlPassword: "sonarPass"
   mysqlDatabase: "sonarDB"


### PR DESCRIPTION
To use already existing secret to connect MySQL you must
define mysql.existingSecret

Fixes #31

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>