### PR TITLE
Fix to --set sonarProperties

### DIFF
--- a/charts/sonarqube/templates/config.yaml
+++ b/charts/sonarqube/templates/config.yaml
@@ -15,7 +15,7 @@ data:
   {{- if or .Values.sonarProperties (not .Values.elasticsearch.bootstrapChecks) }}
   sonar.properties:
   {{ range $key, $val := .Values.sonarProperties }}
-    {{ $key }}={{ $val }}
+    {{ $val }}
   {{ end }}
   {{- if not .Values.elasticsearch.bootstrapChecks }}
     sonar.es.bootstrap.checks.disable=true


### PR DESCRIPTION
Hi @rjkernick ( et. al. ), can you please review this contribution ?


**Story**

As a sonarqube admin, I would like to use sonarqube's marketplace at _"my-corp"_ network, so that I may install whatever plugins are deemed relevant for _"my-corp"_ 's needs.

**Issue**

_"my-corp"_ 's  network is behind a firewall, thus requiring `http.proxyHost` and `http.proxyPort` to be set in `sonar.properties`.

However, `--set sonarProperties={ ... }` is not properly injecting the values into sonar.properties.

**Repro path**

1. Install sonarqube. 
  1.1. Example: `helm install -n sonarqube oteemocharts/sonarqube (...) --set replicaCount=1 --set service.type=NodePort --set sonarProperties={ "http.proxyHost=proxy.mycorp.com, http.proxyPort=8080" }`
2. Wait for Sonarqube to be up at <NodePort>, access it at `ip:nodePort`
3. Login as admin, navigate to `Administration > Marketplace`
4. Wait until loading animation ends:
  4.1. **Expected**: list of available plugins
  4.2. **Actual**: no results shown

**Root cause**

1. Do `kubectl logs <pod> -n sonarqube` 
  1.1. Notice the stacktraces: 
```
org.sonar.api.utils.SonarException: Fail to download: https://update.sonarsource.org/update-center.properties (no proxy)
	at org.sonar.core.util.DefaultHttpDownloader.failToDownload(DefaultHttpDownloader.java:155)
	at org.sonar.core.util.DefaultHttpDownloader.readString(DefaultHttpDownloader.java:113)
	at org.sonar.api.utils.UriReader.readString(UriReader.java:69)
	at org.sonar.server.plugins.UpdateCenterClient.init(UpdateCenterClient.java:99)
         (...)
``` 
2. `docker exec` into the sonarqube container: `docker exec -it $( docker ps | grep sonarqube_sonarqube | cut -b -15 ) /bin/bash`
3. `cat conf/sonar.properties`
   3.1. **Expected**: 
```
http.proxyHost=proxy.wal.hds.com
http.proxyPort=8080
```
   3.2. **Actual**: 
```
0=http.proxyHost=proxy.wal.hds.com
1=http.proxyPort=8080
```

With this fix, sonar.properties 's values get properly injected, and consequently, our sonarqube deployment is able to list all marketplace plugins, as well as install them.
