### PR TITLE
Update Nexus default imageTag to latest to fix vulnerability

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.26.0
-appVersion: 3.20.1-01
+version: 1.26.1
+appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - artifacts

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -10,7 +10,7 @@ deploymentStrategy: {}
 
 nexus:
   imageName: sonatype/nexus3
-  imageTag: 3.20.1
+  imageTag: 3.21.2
   imagePullPolicy: IfNotPresent
   # Uncomment this to scheduler pods on priority
   # priorityClassName: "high-priority"


### PR DESCRIPTION
charts/sonatype-nexus - Update nexus imageTag to latest

Ref: https://help.sonatype.com/repomanager3/release-notes/2020-release-notes#id-2020ReleaseNotes-RepositoryManager3.21.2