### PR TITLE
nexus: Update route template; Update deployment template

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.26.1
+version: 1.26.2
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -218,9 +218,9 @@ spec:
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 8 }}
         {{- end }}
-      {{- if .Values.nexus.securityContext.enabled }}
+      {{- if .Values.nexus.securityContextEnabled }}
       securityContext:
-        fsGroup: {{.Values.nexus.securityContext.fsGroup }}
+{{ toYaml .Values.nexus.securityContext | indent 8 }}  
       {{- end }}
       volumes:
         {{- if .Values.nexusProxy.env.cloudIamAuthEnabled }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -220,7 +220,7 @@ spec:
         {{- end }}
       {{- if .Values.nexus.securityContextEnabled }}
       securityContext:
-{{ toYaml .Values.nexus.securityContext | indent 8 }}  
+{{ toYaml .Values.nexus.securityContext | indent 8 }}
       {{- end }}
       volumes:
         {{- if .Values.nexusProxy.env.cloudIamAuthEnabled }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -218,9 +218,9 @@ spec:
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 8 }}
         {{- end }}
-      {{- if .Values.nexus.securityContext }}
+      {{- if .Values.nexus.securityContext.enabled }}
       securityContext:
-{{ toYaml .Values.nexus.securityContext | indent 8 }}
+        fsGroup: {{.Values.nexus.securityContext.fsGroup }}
       {{- end }}
       volumes:
         {{- if .Values.nexusProxy.env.cloudIamAuthEnabled }}

--- a/charts/sonatype-nexus/templates/route.yaml
+++ b/charts/sonatype-nexus/templates/route.yaml
@@ -24,4 +24,6 @@ spec:
 {{- end }}
     weight: 100
   wildcardPolicy: None
+status:
+  ingress: []
 {{- end }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -50,7 +50,7 @@ nexus:
   # loadBalancerSourceRanges:
   #   - 192.168.1.10/32
   # labels: {}
-  securityContextEnabled: true 
+  securityContextEnabled: true
   securityContext:
     fsGroup: 2000
   podAnnotations: {}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -50,8 +50,8 @@ nexus:
   # loadBalancerSourceRanges:
   #   - 192.168.1.10/32
   # labels: {}
+  securityContextEnabled: true 
   securityContext:
-    enabled: true
     fsGroup: 2000
   podAnnotations: {}
   livenessProbe:

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -51,6 +51,7 @@ nexus:
   #   - 192.168.1.10/32
   # labels: {}
   securityContext:
+    enabled: true
     fsGroup: 2000
   podAnnotations: {}
   livenessProbe:


### PR DESCRIPTION
This PR updates the Route and Deployment templates for sonatype-nexus.

*Route*:
- Template needs to have an empty stubbed status object. Otherwise this throws an error (likely due to some openAPI validation that is being done)

*Deployment*:
- When trying to set an empty securityContext (ie `securityContext: []`) a warning is thrown about replacing a table value with a non-table value. Adding the `enabled` field similar to other charts makes this more straightforward to use. I've also defaulted the `enabled` field to true to maintain current functionality.