### PR TITLE
Typo fix for the nexusiq readme for template

### DIFF
--- a/charts/nexusiq/Chart.yaml
+++ b/charts/nexusiq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 1.63.0
-version: 1.0.2
+version: 1.0.3
 description: A Helm chart for Nexus IQ
 name: nexusiq
 keywords:

--- a/charts/nexusiq/README.md
+++ b/charts/nexusiq/README.md
@@ -16,7 +16,7 @@ This chart bootstraps a Nexus IQ deployment on a cluster using Helm.
 ## Installing the Chart
 
 ### Helm 2.x + Tiller
-```bash 
+```bash
 $ helm install oteemo.github.io/charts/nexusiq
 ```
 
@@ -24,8 +24,8 @@ $ helm install oteemo.github.io/charts/nexusiq
 
 To install this chart in a tiller-less environment in helm 2.x:
  1. Complete the values file with your values.
- 2. Execute the ```helm tempalte``` command to generate your manifest files
- 3. Execute the ```kubectl apply``` command to create the deployment within your kubernetes cluster. 
+ 2. Execute the ```helm template``` command to generate your manifest files
+ 3. Execute the ```kubectl apply``` command to create the deployment within your kubernetes cluster.
 
 ## Testing the Chart
 
@@ -90,8 +90,8 @@ After installing the chart a couple of actions still need to be done in order to
 
 ### NexusIQ Configuration
 The following steps need to be executed in order to use NexusIQ:
- 1. Install the license. Without a valid license you will not be able to navigate past the license page and use NexusIQ in any way. 
- 2. Configure basic permissions. By default NexusIQ creates a default `admin` user with a password of `admin123` that is not configurable at boostrap. You MUST change this immediately upon logging in. 
+ 1. Install the license. Without a valid license you will not be able to navigate past the license page and use NexusIQ in any way.
+ 2. Configure basic permissions. By default NexusIQ creates a default `admin` user with a password of `admin123` that is not configurable at boostrap. You MUST change this immediately upon logging in.
  3. (Optional) Configure LDAP.
 
 ### Nexus IQ Server System Requirements
@@ -104,13 +104,13 @@ The following table lists the system requirements of the Nexus IQ Server
 | `Disk`                            | Storage requirements range with the number of applications projected to use the IQ Server. 500 GB to 1 TB of free disk space should provide more than adequate resources. |
 | `Account` | It is recommended that an unprivileged service account be created if running the IQ Server as a daemon. |
 | `Operating System` | Generally, any machine that can run a supported Sun/Oracle Java version should work. Refer to the Oracle documentation for specifics: Oracle JDK 8 and JRE 8 Certified System Configurations. The most widely used operating system for the IQ Server is Linux and therefore customers should consider it the best tested platform. |
-| `Ports` | The IQ Server requires the following network access. Inbound: 8070 TCP: Used by all IQ Server clients for HTTP access. This port is configurable. 8071 TCP: Used by the local host or other IT monitoring tools for monitoring and operating functions. This port is optional and configurable. If not specified, port 8081 will be used. Outbound: 443 TCP to https://clm.sonatype.com : Used by the IQ Server to securely access Sonatype Data Services. This hostname and port are not configurable. Sonatype Data Services must be reachable by IQ Server on the following URL: https://clm.sonatype.com/ . | 
+| `Ports` | The IQ Server requires the following network access. Inbound: 8070 TCP: Used by all IQ Server clients for HTTP access. This port is configurable. 8071 TCP: Used by the local host or other IT monitoring tools for monitoring and operating functions. This port is optional and configurable. If not specified, port 8081 will be used. Outbound: 443 TCP to https://clm.sonatype.com : Used by the IQ Server to securely access Sonatype Data Services. This hostname and port are not configurable. Sonatype Data Services must be reachable by IQ Server on the following URL: https://clm.sonatype.com/ . |
 | `Java` | OpenJDK 8 (since December 2018, IQ Server release 55). Prior to IQ Server release 63, the IQ Server used to check if the used JVM is supported. This check does not work for certain OpenJDK versions/flavors. You can disable this check by adding -Dclm.disableJreCheck=true to the command used to start the IQ Server. |
 
 
 ### Important Links
 
-1. Nexus IQ Server Web Page - https://www.sonatype.com/nexus-iq-server 
-2. Nexus IQ Server Documentation & Help Page - https://help.sonatype.com/iqserver 
+1. Nexus IQ Server Web Page - https://www.sonatype.com/nexus-iq-server
+2. Nexus IQ Server Documentation & Help Page - https://help.sonatype.com/iqserver
 3. Nexus IQ Server Getting Started Guide - https://help.sonatype.com/iqserver/getting-started
-4. Nexus IQ Docker Repo & Docker Documentation - https://hub.docker.com/r/sonatype/nexus-iq-server 
+4. Nexus IQ Docker Repo & Docker Documentation - https://hub.docker.com/r/sonatype/nexus-iq-server


### PR DESCRIPTION
Why do we need this change?
----
There is a typo in the instructions related to running helm template. As
someone might run it natively avoid having errors that cause support
requests. Also resolve some issues with extra spaces at the end of several lines

What effects does this change have?
----
* Changes the README.md command for helm template to fix a typo
* General lint fixes related to added spaces at the end of lines