### PR TITLE
Set ingress.rules indent to 4

### DIFF
--- a/charts/sonatype-nexus/templates/ingress.yaml
+++ b/charts/sonatype-nexus/templates/ingress.yaml
@@ -47,7 +47,7 @@ spec:
   {{- end }}
 {{- end -}}
 {{- with .Values.ingress.rules  }}
-{{ toYaml . | indent 2 }}
+{{ toYaml . | indent 4 }}
   {{- end -}}
 {{- if .Values.ingress.tls.enabled }}
   tls:


### PR DESCRIPTION
Fixes #43 

I was unable to supply custom ingress rules without this. Otherwise you get the error:
```
UPGRADE FAILED: YAML parse error on sonatype-nexus/templates/ingress.yaml: error converting YAML to JSON: yaml: line 26: did not find expected key
```