### PR TITLE
Fix deleteDefaultPlugins default value

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 5.1.0
+version: 5.1.1
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `plugins.initVolumesContainerImage`   | Change init volumes container image                                          | `busybox:1.31`                                 |
 | `plugins.initCertsContainerImage`     | Change init ca certs container image                                         | `adoptopenjdk/openjdk11:alpine`                |
 | `plugins.initTestContainerImage`      | Change init test container image                                             | `dduportal/bats:0.4.0`                         |
-| `plugins.deleteDefaultPlugins`        | Remove default plugins and use plugins.install list                          | `[]`                                           |
+| `plugins.deleteDefaultPlugins`        | Remove default plugins and use plugins.install list                          | false                                           |
 | `plugins.httpProxy`                   | For use behind a corporate proxy when downloading plugins                    | ""                                             |
 | `plugins.httpsProxy`                  | For use behind a corporate proxy when downloading plugins                    | ""                                             |
 | `podLabels`                           | Map of labels to add to the pods                                             | `{}`                                           |


### PR DESCRIPTION
In https://github.com/Oteemo/charts/blob/f4f684482b7a4f569482635a10851d7b99669a91/charts/sonarqube/templates/copy-plugins.yaml#L13 the deleteDefaultPlugins is used as a boolean as in values.yaml example.