### PR TITLE
fix ingress rules substitution

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.26.3
+version: 1.26.4
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/templates/ingress.yaml
+++ b/charts/sonatype-nexus/templates/ingress.yaml
@@ -46,8 +46,8 @@ spec:
             path: {{ .Values.ingress.path }}
   {{- end }}
 {{- end -}}
-  {{- with .Values.ingress.rules  }}
-{{- toYaml . | indent 4 }}
+  {{- with .Values.ingress.rules }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- if .Values.ingress.tls.enabled }}
   tls:


### PR DESCRIPTION
Howdy, finally located an irritating template bug when using custom rules.

```
failed processing release nexus: helm exited with status 1:
  Error: YAML parse error on sonatype-nexus/templates/ingress.yaml: error converting YAML to JSON: yaml: line 22: mapping values are not allowed in this context
  Error: plugin "diff" exited with error
```