### PR TITLE
Decouple nexusBackup.enabled and nexusBackup.persistence.enabled

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.26.7
+version: 1.27.0
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.26.6
+version: 1.26.7
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/templates/backup-pvc.yaml
+++ b/charts/sonatype-nexus/templates/backup-pvc.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.statefulset.enabled }}
-{{- if and .Values.nexusBackup.enabled (and .Values.nexusBackup.persistence.enabled (not .Values.nexusBackup.persistence.existingClaim)) }}
+{{- if and and .Values.nexusBackup.persistence.enabled (not .Values.nexusBackup.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/sonatype-nexus/templates/backup-pvc.yaml
+++ b/charts/sonatype-nexus/templates/backup-pvc.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.statefulset.enabled }}
-{{- if and and .Values.nexusBackup.persistence.enabled (not .Values.nexusBackup.persistence.existingClaim) }}
+{{- if and .Values.nexusBackup.persistence.enabled (not .Values.nexusBackup.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -234,7 +234,7 @@ spec:
         - name: {{ template "nexus.fullname" . }}-data
           emptyDir: {}
         {{- end }}
-        {{- if not (and .Values.nexusBackup.enabled .Values.nexusBackup.persistence.enabled) }}
+        {{- if not .Values.nexusBackup.persistence.enabled }}
         - name: {{ template "nexus.fullname" . }}-backup
           emptyDir: {}
         {{- end }}
@@ -247,7 +247,7 @@ spec:
           emptyDir: {}
           {{- end }}
         - name: {{ template "nexus.fullname" . }}-backup
-          {{- if and .Values.nexusBackup.enabled (.Values.nexusBackup.persistence.enabled) }}
+          {{- if .Values.nexusBackup.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.nexusBackup.persistence.existingClaim | default (printf "%s-%s" (include "nexus.fullname" .) "backup") }}
           {{- else }}
@@ -300,7 +300,7 @@ spec:
         {{- end }}
     {{- end }}
 
-    {{- if and .Values.nexusBackup.enabled (.Values.nexusBackup.persistence.enabled) }}
+    {{- if .Values.nexusBackup.persistence.enabled }}
     - metadata:
         name: {{ template "nexus.fullname" . }}-backup
         labels:


### PR DESCRIPTION
Let the user decides if it requires the backup persistent storage regardless
its opinion on backup container feature.

Fixes #68