### PR TITLE
Fix sonatype nexus deployment strategy

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 1.27.1
+version: 1.27.2
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
   {{- end }}
   {{- if .Values.deploymentStrategy }}
   strategy:
-{{ toYaml .Values.deploymentStrategy | indent 4 }}
+    type: {{ .Values.deploymentStrategy }}
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
Added the missing `type` property to the deployment strategy property.

This should resolve #77