### PR TITLE
Nexus: Add template to include additional configmaps

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.0.0
+version: 2.0.1
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.0.1
+version: 2.1.0
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -167,6 +167,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `route.labels`          | Labels to be added to route                        | `{}` |
 | `route.annotations`     | Annotations to be added to route                   | `{}` |
 | `route.path`            | Host name of Route e.g jenkins.example.com         | nil |
+| `additionalConfigMaps`  | List of ConfigMap data containing Name, Data and Labels | nil |
 
 If `nexusProxy.env.cloudIamAuthEnabled` is set to `true` the following variables need to be configured
 

--- a/charts/sonatype-nexus/templates/adtl-configmap.yaml
+++ b/charts/sonatype-nexus/templates/adtl-configmap.yaml
@@ -1,0 +1,21 @@
+{{ $root := . }}
+{{- if .Values.additionalConfigMaps }}
+{{- range $cm := .Values.additionalConfigMaps }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $cm.name }}
+  labels:
+{{ include "nexus.labels" $root | indent 4 }}
+{{- if $.Values.nexus.labels }}
+{{ toYaml $.Values.nexus.labels | indent 4 }}
+{{- end }}
+{{- if $cm.labels }}
+{{ toYaml $cm.labels | indent 4 }}
+{{- end }}
+data:
+{{ toYaml $cm.data | indent 2 }}
+{{- end }}
+{{- end }}
+

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -241,3 +241,15 @@ service:
   - name: nexus-service
     targetPort: 80
     port: 80
+
+additionalConfigMaps: []
+#  - name: maven-central
+#    labels:
+#      nexus-type: repository
+#    data:
+#      recipe: 'MavenProxy'
+#      remoteUrl: 'https://repo.maven.apache.org/maven2/'
+#      blobStoreName: 'default'
+#      strictContentTypeValidation: 'true'
+#      versionPolicy: 'RELEASE'
+#      layoutPolicy: 'STRICT'


### PR DESCRIPTION
This PR adds the ability to include additional ConfigMaps as part of your Nexus deployment. This is particularly useful if you are using Nexus plugins that happen to expect input from ConfigMaps (for example: https://github.com/sonatype-nexus-community/nexus-kubernetes-openshift). Once this is merged, users will then be able to use this chart to use this helm chart for the complete deployment versus being able to include the plugin, but having to configure it seperately from the chart.

Closes #79 