### PR TITLE
Initial commit to add more control over the ingress

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.0.1
+version: 6.0.2
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -25,6 +25,15 @@ metadata:
 {{- end }}
 spec:
   rules:
+    {{- range .Values.additionalIngress.hosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ .path}}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+    {{- end -}}
     {{- range .Values.ingress.hosts }}
     - host: {{ .name }}
       http:

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -56,7 +56,14 @@ ingress:
   # - secretName: chart-example-tls
   #   hosts:
   #     - chart-example.local
-
+# additionalIngress:
+#   # Used to create an additonal Ingress record with more control of serviceName/servicePort.
+#   hosts:
+#     - name: sonar.organization.com
+#       serviceName:
+#       servicePort:
+#       # Different clouds or configurations might need /* as the default path
+#       path: /
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}


### PR DESCRIPTION
Solves Issue #98 (https://github.com/Oteemo/charts/issues/98)

Allows for the user to add an additional Ingress in case they are using the ALB Ingress controller or need to use a servicePort other than the .Values.service.externalPort as the default option.
