### PR TITLE
Add default deployment annotations

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.1.1
+version: 6.2.0
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.1.0
+version: 6.1.1
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -25,8 +25,11 @@ spec:
 {{- with .Values.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{ if .Values.annotations}}
       annotations:
+        checksum/plugins: {{ include (print $.Template.BasePath "/install-plugins.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- if .Values.annotations}}
       {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}


### PR DESCRIPTION
Adding checksum annotations to force update the deployment if configmap/secrets are changed. 

Currently updating any of the following values does not update the deployment. Changes are only applied after force recreating the pods.
```
plugins:
  install:

sonarProperties:
```
[Documentation](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)