### PR TITLE
allow SonarQube to terminate gracefully when its container is killed

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.1.1
+version: 6.2.1
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.1.0
+version: 6.1.1
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/copy-plugins.yaml
+++ b/charts/sonarqube/templates/copy-plugins.yaml
@@ -30,4 +30,4 @@ data:
       cp -f {{ $.Values.sonarqubeFolder }}/extensions/plugins/{{ $val }} {{ $.Values.sonarqubeFolder }}/lib/common/
       {{- end }}
       {{- end }}
-      {{ .Values.sonarqubeFolder }}/bin/run.sh
+      exec {{ .Values.sonarqubeFolder }}/bin/run.sh


### PR DESCRIPTION
the kill signal sent to SQ container is caught by the copy-plugin script and never sent to SQ itself
sending the signal to SQ allows it to terminate gracefully its connections (DB) and processes (CE, ES)