### PR TITLE
Sonarqube hidden native plugins fix

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.2.1
+version: 6.2.2
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -54,8 +54,8 @@ spec:
           command:
             - "sh"
             - "-c"
-            - 'mkdir -p $(printf "/opt/sonarqube/${1-%s\n}" temp logs data extensions/downloads extensions/plugins/tmp extensions/plugins certs) &&
-               chown 999:999 -R $(printf "/opt/sonarqube/${1-%s\n}" temp logs data extensions/downloads extensions/plugins/tmp extensions/plugins certs)'
+            - 'mkdir -p $(printf "/opt/sonarqube/${1-%s\n}" temp logs data extensions/downloads extensions/plugins/tmp certs) &&
+               chown 999:999 -R $(printf "/opt/sonarqube/${1-%s\n}" temp logs data extensions/downloads extensions/plugins/tmp certs)'
           volumeMounts:
           - mountPath: /opt/sonarqube/temp
             name: sonarqube
@@ -72,9 +72,6 @@ spec:
           - mountPath: /opt/sonarqube/extensions/downloads
             name: sonarqube
             subPath: downloads
-          - mountPath: /opt/sonarqube/extensions/plugins
-            name: sonarqube
-            subPath: plugins
           - mountPath: /opt/sonarqube/certs
             name: sonarqube
             subPath: certs
@@ -247,9 +244,6 @@ spec:
             - mountPath: {{ .Values.sonarqubeFolder }}/extensions/downloads
               name: sonarqube
               subPath: downloads
-            - mountPath: {{ .Values.sonarqubeFolder }}/extensions/plugins
-              name: sonarqube
-              subPath: plugins
             - mountPath: {{ .Values.sonarqubeFolder }}/temp
               name: sonarqube
               subPath: temp


### PR DESCRIPTION
remove extensions/plugins creation and mounts from the chart to avoid native plugins to be hidden when extra plugins are needed

should fix #61

Maybe I have missed something because I absolutely do not understand why this directory is declared and mount as a volume : the extra plugins were already copied directly in the extensions/plugins by the copy-plugins.sh script from /extensions/plugins/tmp where they are downloaded by the install-plugins.sh script (init container).

This fix has been checked with no extra plugin, some extra plugins, updated native plugins (which was already taken in account by the copy-plugins.sh script by removing old version of native plugin in /extensions/plugins) and with a container crash to check that the extra plugins are stilled copied in the /extensions/plugins directory when the container is restarted
