### PR TITLE
Deployment render bugfix

### DIFF
--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -125,9 +125,11 @@ spec:
               subPath: tmp
             - name: install-plugins
               mountPath: /tmp/scripts/
+          {{- if .Values.env }}
           {{- with .Values.env }}
           env:
             {{- . | toYaml | trim | nindent 12 }}
+          {{- end }}
           {{- end }}
           resources:
 {{ toYaml .Values.plugins.resources | indent 12 }}


### PR DESCRIPTION
Currently, the deployment manifest fails to render if values for `sonarProperties` and `sonarSecretProperties` no value for `env` is present. This PR introduces a guard to check if `env` is defined but Im not sure if that is the best solution. It seems like the field itself is completely commented out in `values.yaml`

https://github.com/Oteemo/charts/blob/ea5ca527935ce0332f45ae92024896fffeaf8400/charts/sonarqube/values.yaml#L111-L115