### PR TITLE
Nexus: Add loadBalancerIP to proxy service and additional services

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.1.0
+version: 2.2.0
 appVersion: 3.21.2
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |
 | `nexus.service.type`                        | Service for Nexus                   |`CluserIP`                                |
 | `nexus.service.clusterIp`                   | Specific cluster IP when service type is cluster IP. Use None for headless service |`nil`   |
+| `nexus.service.loadBalancerIP`                        | Custom loadBalancerIP                   |`nil`                                |
 | `nexus.securityContextEnabled`                     | Security Context (for enabling official image use `fsGroup: 200`) | `{}`     |
 | `nexus.labels`                              | Service labels                      | `{}`                                    |
 | `nexus.podAnnotations`                      | Pod Annotations                     | `{}`
@@ -156,6 +157,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `service.labels`                            | Service labels                   | `nil`                                      |
 | `service.annotations`                       | Service annotations              | `nil`                                      |
 | `service.loadBalancerSourceRanges`          | Service LoadBalancer source IP whitelist | `nil`                              |
+| `service.loadBalancerIP`                        | Custom loadBalancerIP                   |`nil`                                |
 | `service.targetPort`                        | Service port                     | `nil`                                      |
 | `service.port`                              | Port for exposing service        | `nil`                                      |
 | `serviceAccount.create`                     | Automatically create a service account | `true`                               |

--- a/charts/sonatype-nexus/templates/proxy-svc.yaml
+++ b/charts/sonatype-nexus/templates/proxy-svc.yaml
@@ -44,4 +44,7 @@ spec:
   {{- if and (eq .Values.nexus.service.type "ClusterIP") .Values.nexus.service.clusterIP }}
   clusterIP: {{ .Values.nexus.service.clusterIP }}
   {{- end }}
+  {{ if eq .Values.nexus.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.nexus.service.loadBalancerIP }}
+  {{ end }}
 {{- end }}

--- a/charts/sonatype-nexus/templates/service.yaml
+++ b/charts/sonatype-nexus/templates/service.yaml
@@ -36,5 +36,8 @@ spec:
     - {{ . }}
     {{- end }}
   {{ end }}
+  {{ if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{ end }}
 {{- end}}
 

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -50,6 +50,8 @@ nexus:
   # loadBalancerSourceRanges:
   #   - 192.168.1.10/32
   # labels: {}
+  ## Configures the requested IP on the loadBalancer when using LoadBalancer service type
+  # loadBalancerIP: "192.168.1.10"
   securityContextEnabled: true
   securityContext:
     fsGroup: 200
@@ -241,6 +243,8 @@ service:
   - name: nexus-service
     targetPort: 80
     port: 80
+  ## Configures the requested IP on the loadBalancer when using LoadBalancer service type
+  # loadBalancerIP: "192.168.1.10"
 
 additionalConfigMaps: []
 #  - name: maven-central


### PR DESCRIPTION
This change allows the setting of custom IPs on Kubernetes services with the LoadBalancer type from within the Helm chart by adding the value to values.yaml