### PR TITLE
Remove initContainer 'chmod-volume-mounts'

### DIFF
--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -49,36 +49,6 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-        - name: chmod-volume-mounts
-          image: {{ default "busybox:1.31" .Values.plugins.initVolumesContainerImage }}
-          command:
-            - "sh"
-            - "-c"
-            - 'mkdir -p $(printf "/opt/sonarqube/${1-%s\n}" temp logs data extensions/downloads extensions/plugins/tmp certs) &&
-               chown 999:999 -R $(printf "/opt/sonarqube/${1-%s\n}" temp logs data extensions/downloads extensions/plugins/tmp certs)'
-          volumeMounts:
-          - mountPath: /opt/sonarqube/temp
-            name: sonarqube
-            subPath: temp
-          - mountPath: /opt/sonarqube/logs
-            name: sonarqube
-            subPath: logs
-          - mountPath: /opt/sonarqube/data
-            name: sonarqube
-            subPath: data
-          - mountPath: /opt/sonarqube/extensions/plugins/tmp
-            name: sonarqube
-            subPath: tmp
-          - mountPath: /opt/sonarqube/extensions/downloads
-            name: sonarqube
-            subPath: downloads
-          - mountPath: /opt/sonarqube/certs
-            name: sonarqube
-            subPath: certs
-          {{- with .Values.env }}
-          env:
-            {{- . | toYaml | trim | nindent 12 }}
-          {{- end }}
       {{- if .Values.caCerts }}
         - name: ca-certs
           image: {{ default "adoptopenjdk/openjdk11:alpine" .Values.plugins.initCertsContainerImage }}


### PR DESCRIPTION
The initContainer `chmod-volume-mounts` contains a hard coded `user-id` and `group-id` and causes problems if not run in privileged mode. The original pull request had the following message:

> My sonarqube was not starting up after I accidentally lost my PVC. I'm not sure if permissions are set in the inital setup, but the current pods were not starting up as all the subdirs were owned by root.

I would recommend removing this container unless necessary. In that case it should be configurable.

This addresses https://github.com/Oteemo/charts/issues/87
Original pull request that introduced this change: https://github.com/helm/charts/pull/17001