### PR TITLE
Update ingress API version for nexus to networking.k8s.io/v1beta1

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.3.0
+version: 2.3.1
 appVersion: 3.23.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -14,7 +14,7 @@ There is also the option of using a [proxy for Nexus](https://github.com/travela
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.15+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
 - [Fulfill Nexus kubernetes requirements](https://github.com/travelaudience/kubernetes-nexus#pre-requisites)
 

--- a/charts/sonatype-nexus/templates/ingress.yaml
+++ b/charts/sonatype-nexus/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "nexus.fullname" . }}


### PR DESCRIPTION
This is the new API version for Ingress since k8s 1.15.
Since older version are not maintained anymore we can change this.

Signed-off-by: Guillaume Perrin <guillaume28.perrin@gmail.com>