### PR TITLE
NEXUS_CONTEXT to run Nexus at a non-root path

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.4.1
+version: 2.4.2
 appVersion: 3.23.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.4.2
+version: 2.5.0
 appVersion: 3.23.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.timeoutSeconds`       | Time in seconds after readiness probe times out    | `nil`                    |
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
 | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
+| `nexus.context`                     | Run Nexus at a non-root path      | `nil`             |
 | `nexusProxy.enabled`                        | Enable nexus proxy                  | `true`                                  |
 | `nexusProxy.svcName`                        | Nexus proxy service name            | `nil`                                  |
 | `nexusProxy.targetPort`                     | Container Port for Nexus proxy      | `8080`                                  |

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -106,7 +106,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.timeoutSeconds`       | Time in seconds after readiness probe times out    | `nil`                    |
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
 | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
-| `nexus.context`                     | Run Nexus at a non-root path      | `nil`             |
+| `nexus.context`                             | Non-root path to run Nexus at       | `nil`                                   |
 | `nexusProxy.enabled`                        | Enable nexus proxy                  | `true`                                  |
 | `nexusProxy.svcName`                        | Nexus proxy service name            | `nil`                                  |
 | `nexusProxy.targetPort`                     | Container Port for Nexus proxy      | `8080`                                  |

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -80,6 +80,11 @@ spec:
           {{- end }}
           env:
 {{ toYaml .Values.nexus.env | indent 12 }}
+{{- if .Values.nexus.context }}
+            - name: NEXUS_CONTEXT
+              value: {{ .Values.nexus.context }}
+{{- end }}
+
           resources:
 {{ toYaml .Values.nexus.resources | indent 12 }}
           ports:

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -77,6 +77,7 @@ nexus:
   #   hostnames:
   #   - "example.com"
   #   - "www.example.com"
+  context:
 
 route:
   enabled: false


### PR DESCRIPTION
Some reverse proxies require a backend application to run at a non-root path so multiple backend applications can be differentiated by paths. However, Nexus generates javascript that requests resources at fixed paths causing pages to display 404. The environment variable NEXUS_CONTEXT tells Nexus to run at a non-root path.

The official documentation: https://github.com/sonatype/docker-nexus3