### PR TITLE
[SONARQUBE] no cacerts handling (FIXED)

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.6.3
+version: 6.6.4
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - name: ca-certs
           image: {{ default "adoptopenjdk/openjdk11:alpine" .Values.plugins.initCertsContainerImage }}
           command: ["sh"]
-          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls -A /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
+          args: ["-c", "cp -f \"${JAVA_HOME}/lib/security/cacerts\" /tmp/certs/cacerts; if [ \"$(ls /tmp/secrets/ca-certs)\" ]; then for f in /tmp/secrets/ca-certs/*; do keytool -importcert -file \"${f}\" -alias \"$(basename \"${f}\")\" -keystore /tmp/certs/cacerts -storepass changeit -trustcacerts -noprompt; done; fi;"]
           volumeMounts:
             - mountPath: /tmp/certs
               name: sonarqube


### PR DESCRIPTION
I am really sorry @rjkernick , I messed up my previous pull request :-(
It did not broke anything but the behavior did not change due to the fact `/tmp/secrets/ca-certs` is not really empty when mounted as a volume.

This new pull request really fixes things.

Tests I performed :

# TEST 1 - No secret

`myvalues.yml` :
```yaml
# Empty
```

```bash
helm upgrade -i sonarqube . -f myvalues.yml`
```

* SonarQube status : Running
* Certificate check : `keytool -list -keystore /opt/sonarqube/certs/cacerts -storepass changeit | grep fake-le-root` => No result

# TEST 2 - No certs

`certificates.yml` :
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: certificates
type: Opaque
data: {}
```

```myvalues.yml
caCerts:
  secret: certificates
```

```bash
kubectl apply -f certificates.yml
helm upgrade -i sonarqube . -f myvalues.yml
```

* SonarQube status : Running
* Certificate check : `keytool -list -keystore /opt/sonarqube/certs/cacerts -storepass changeit | grep fake-le-root` => No result

# TEST 3 - With certificates

`certificates.yml` :
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: certificates
type: Opaque
data:
  fake-le-root-x1.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZBVENDQXVtZ0F3SUJBZ0lSQUtjOVpLQkFTeW15NVRMT0VwNTdOOTh3RFFZSktvWklodmNOQVFFTEJRQXcKR2pFWU1CWUdBMVVFQXd3UFJtRnJaU0JNUlNCU2IyOTBJRmd4TUI0WERURTJNRE15TXpJeU5UTTBObG9YRFRNMgpNRE15TXpJeU5UTTBObG93R2pFWU1CWUdBMVVFQXd3UFJtRnJaU0JNUlNCU2IyOTBJRmd4TUlJQ0lqQU5CZ2txCmhraUc5dzBCQVFFRkFBT0NBZzhBTUlJQ0NnS0NBZ0VBK3BZSHZRdzVpVTN2MmIzaU51WU5LWWdzV0Q2S1U3YUoKZGlkZHRaUXhTV1l6VUkzVTBJMVVzUlBUeG5oVGlmcy9NOU5XNFpsVjEzWmZCN0FQd0M4b3FLT0lpd283SXdsUAp4ZzBWS2d5eitrVDhSSmZZcjY2UFBJWVAwZnBUZXU0MkxwTUorQ0tvOXNicGdWTkRaTjJ6L3FpWHJSTlgvVnRHClRrUFY3YTQ0Zlo1YkhIVnJ1QXh2RG55bHBReEpvYnRDQldsSlNzYklSR0ZITWMyejg4ZVV6OU5tSU9XVUtHR2oKRW1QNzZ4OE9mUkhwSXB1eFJTQ2puMCtpOStoUjJzaUlPcGNNT0dkKzQwdVZKeGJSUlA1WlhuVUZhMmZGNUZXZApPMHUwUlBJOEhPTjBvdmhyd1BKWSs0ZVdLa1F6eUM2MTFvTFBZR1E0RWJpZlJzVHNDeFVacXlVdVN0R3lwOG9hCmFvU0tmRjZYMCtLekdnd3ducmpSVFVwSWwxOUE5MktSME5vbzZoNjIyT1grNHNaaU8vSlFka3VYNXcvSHVwSzAKQTBNMFdTTUN2VTZHT2hqR290bWgyVlRFSndISFk0K1RVazBpUVlSdHYxY3JPTmtseVpvQVFQRDc2aENyQzhDcgpJYmdzWkxmVE1DOFRXVW9NYnlVRGd2Z1lrSEtNb1BtMFZHVlZ1d3BSS0p4djcrMndYTytwaXZyclVsMlE5ZlBlCktrMDU1bkpMTVY5eVBVZGlnOG90aFVLclJmU3hsaTk0NkFFVjFlRU9oeGRkZkV3QkUzTHQyeG4waGhpSWVkYmIKRnRmLzVrRVdGWmtYeVVtTUpLOFJhNzZLdXMyQUJ1ZVVWRWNaNDhoclJyMUhmMU45bjU5VmJUVWFYZ2VpWkE1MApxWGYyYnltRTZGOENBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC9CQVFEQWdFR01BOEdBMVVkRXdFQi93UUZNQU1CCkFmOHdIUVlEVlIwT0JCWUVGTUVtZEtTS1JLRG0raUFvMkZ3am1rV0lHSG5nTUEwR0NTcUdTSWIzRFFFQkN3VUEKQTRJQ0FRQkNQdzc0TTlYL1h4MDRLMVZBRVMzeXBnUVlINWJmOUZYVkRyd2hSRlNWY2tyaWEvN2RNem9GNXdsbgp1cTlOR3Nqa2trRGcxN0FvaGNRZHI4YWxINEx2UGR4cEtyM0JqcHZFY21icUY4eEgrTWJiZVVFbm1iU2ZMSThICnNlZnVoWEY5QUYvOWlZdnBWTkM4Rm1KME9oaVZ2MTNWZ01RdzBDUktrYnRqWkJmOHhhRWhxL1lxeFdWc2dPam0KZG01Q0FRMlgwYVg3NTAyeDh3WVJnTW5aaEE1Z29DMXpWV0JWQWk4eWhobWxoaG9EVWZnMTdjWGttYUpDNXBEZApvZW5aOU5WaFc4ZURiMDNNRkNyV052SWg4OUREZUNHV3VXZkRsdERxMG4zb3d5TDBJZVNuN1JmcFNjbHB4Vm1WCi81M2prWWp3SWd4SUc3R3N2MExLTWJzZjZRZEJjVGpodmZaeU1JcEJSa1RlM3p1SGQyZmVLelk5bEVrYlJ2UlEKemJoNFBzNVlCbkc2Q0tKUFRiZTJoZmkzbmhudy9NeUVtRjN6YjBoenZMV05yUjlYVzNpYmIyb0wzNDI0WE93YwpWanJUU0NMek85UnY2czV3aTAzcW9XdktBUVFBRWxxVFlSSGh5bkozdzZ3dXZLWUY1emNaRjNNRG5yVkdMYmgxClE5ZVBSRkJDaVhPUTZ3UExvVWhycmJaOExwRlVGWURYSE10WU03UDlzYzlJQVdvT05YUkVKYU8wOHpnRnRNcDQKOGl5SVlVeVFBYnN2eDhvRDJNOGtSdnJJUlNyUkpTbDZMOTU3YjRBRmlMSVEvR2dWMmN1cnMwamplN0VkeDM0YwppZFd3MVZyZWp0d2Nsb2JxTk1WdEczRWlQVUlwSkdwYk1jSmdiaUxTbUtrcnZRdEduZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
```

```myvalues.yml
caCerts:
  secret: certificates
```

```bash
kubectl apply -f certificates.yml
helm upgrade -i sonarqube . -f myvalues.yml
```

* SonarQube status : Running
* Certificate check : `keytool -list -keystore /opt/sonarqube/certs/cacerts -storepass changeit | grep fake-le-root` => `fake-le-root-x1.crt, Sep 4, 2020, trustedCertEntry`


Sorry again for the waste of time.