### PR TITLE
Add option to use existing secret with sonatype nexus

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.7.3
+version: 2.8.0
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.7.2
+version: 2.7.3
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -160,7 +160,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `secret.enabled`                            | Enable secret                    | `false`                                    |
 | `secret.mountPath`                          | Path to mount the secret         | `/etc/secret-volume`                       |
 | `secret.readOnly`                           | Secret readonly state            | `true`                                     |
-| `secret.data`                               | Secret data                      | `nil`                                      |
+| `secret.data`                               | Secret data to add to secret. If nil then expects that a secret by name of `${.Values.nameOverride}-secret` or `${.Chart.Name}-secret` exists                      | `nil`                                      |
 | `service.enabled`                           | Enable additional service        | `nil`                                      |
 | `service.name`                              | Service name                     | `nil`                                      |
 | `service.portName`                          | Service port name                | `nil`                                      |

--- a/charts/sonatype-nexus/templates/secret.yaml
+++ b/charts/sonatype-nexus/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.enabled -}}
+{{- if and .Values.secret.enabled .Values.secret.data -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Hi,

We prefer to use sealed secrets and hence would like the nexus chart to allow using existing secret. This will help us not having to push our secret in unencrypted form to our Git CASC repo.

I have slightly modified the chart so that if you enabled secret but not provided any data then it will expect that the secret already exists