### PR TITLE
Sonarqube: pass caCerts also to the Compute Engine JVM

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.7.1
+version: 6.7.2
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -167,6 +167,10 @@ spec:
               {{- else }}
               value: "{{ .Values.jvmOpts }}"
               {{- end }}
+            - name: SONAR_CE_JAVAOPTS
+              {{- if .Values.caCerts }}
+              value: {{ printf "-Djavax.net.ssl.trustStore=%s/certs/cacerts" .Values.sonarqubeFolder | trim | quote }}
+              {{- end }}
             - name: SONARQUBE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -167,10 +167,10 @@ spec:
               {{- else }}
               value: "{{ .Values.jvmOpts }}"
               {{- end }}
+            {{- if .Values.caCerts }}
             - name: SONAR_CE_JAVAOPTS
-              {{- if .Values.caCerts }}
               value: {{ printf "-Djavax.net.ssl.trustStore=%s/certs/cacerts" .Values.sonarqubeFolder | trim | quote }}
-              {{- end }}
+            {{- end }}
             - name: SONARQUBE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -103,7 +103,7 @@ livenessProbe:
   # sonar.web.context: /sonarqube
 
 ## Provide a secret containing one or more certificate files in the keys that will be added to cacerts
-## The cacerts file will be set via SONARQUBE_WEB_JVM_OPTS
+## The cacerts file will be set via SONARQUBE_WEB_JVM_OPTS and SONAR_CE_JAVAOPTS
 ##
 # caCerts:
 #   secret: my-secret


### PR DESCRIPTION
First of all, thanks for creating this chart!
As we ran into some problems with the Webhook functionality, I found out there is a small issue with the way custom CA certificates are handled in the chart. The custom trustStore that is created from caCerts.secret was only passed to the Web JVM of SonarQube, but the Webhooks are called from the Compute Engine JVM.
The variable SONAR_CE_JAVAOPTS can be used to set JVM parameters for the Compute Engine, so I added it to the container env.
Another option would be to add the certs to the default trustStore of the JRE inside the container, just like update-ca-certificates would do it.
This fixes #125 