### PR TITLE
Fix Sonarqube health check

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 6.7.2
+version: 6.7.3
 appVersion: 8.2-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -189,13 +189,13 @@ spec:
 {{- end }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.sonarWebContext }}sessions/new
+              path: {{ .Values.livenessProbe.sonarWebContext }}api/system/status
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.sonarWebContext }}sessions/new
+              path: {{ .Values.readinessProbe.sonarWebContext }}api/system/status
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/sonarqube/templates/tests/test-config.yaml
+++ b/charts/sonarqube/templates/tests/test-config.yaml
@@ -11,6 +11,6 @@ metadata:
 data:
   run.sh: |-
     @test "Testing Sonarqube UI is accessible" {
-      curl --connect-timeout 5 --retry 12 --retry-delay 1 --retry-max-time 60 {{ template "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}/sessions/new
+      curl --connect-timeout 5 --retry 12 --retry-delay 1 --retry-max-time 60 {{ template "sonarqube.fullname" . }}:{{ .Values.service.internalPort }}/api/system/status
     }
 {{- end -}}


### PR DESCRIPTION
Sonarqube are restarting because `/sessions/new` is not the endpoint to be checked Sonarqube healthy.

https://community.sonarsource.com/t/using-the-health-check-api/16325