### PR TITLE
split ingress into http ingress and docker ingress 

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.8.1
+version: 3.0.0
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 2.8.0
+version: 2.8.1
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -147,6 +147,11 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |
 | `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
 | `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
+| `ingressDocker.enabled`                           | Create an ingress for Docker registry         | `false`                                  |
+| `ingressDocker.annotations`                       | Annotations to enhance docker ingress configuration  | `{}`                          |
+| `ingressDocker.tls.enabled`                       | Enable TLS                          | `true`                                 |
+| `ingressDocker.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
+| `ingressDocker.path`                              | Path for docker ingress rules. GCP users should set to `/*` | `/`                    |
 | `tolerations`                               | tolerations list                    | `[]`                                    |
 | `config.enabled`                            | Enable configmap                    | `false`                                 |
 | `config.mountPath`                          | Path to mount the config            | `/sonatype-nexus-conf`                  |

--- a/charts/sonatype-nexus/templates/_helpers.tpl
+++ b/charts/sonatype-nexus/templates/_helpers.tpl
@@ -58,3 +58,10 @@ chart: {{ template "nexus.chart" . }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create a fully qualified name for docker ingress.
+*/}}
+{{- define "nexus.ingres.docker" -}}
+{{- printf "%s-%s" (include "nexus.fullname" .) "docker" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/sonatype-nexus/templates/ingress-docker.yaml
+++ b/charts/sonatype-nexus/templates/ingress-docker.yaml
@@ -1,22 +1,22 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingressDocker.enabled .Values.nexusProxy.enabled }}
 apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "nexus.fullname" . }}
+  name: {{ template "nexus.ingres.docker" . }}
   namespace: {{ template "nexus.namespace" . }}
   labels:
 {{ include "nexus.labels" . | indent 4 }}
-    {{- range $key, $value := .Values.ingress.labels }}
+    {{- range $key, $value := .Values.ingressDocker.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
+    {{- range $key, $value := .Values.ingressDocker.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-{{- if .Values.nexusProxy.env.nexusHttpHost }}
-    - host: {{ .Values.nexusProxy.env.nexusHttpHost }}
+  {{- if .Values.nexusProxy.env.nexusDockerHost }}
+    - host: {{ .Values.nexusProxy.env.nexusDockerHost }}
       http:
         paths:
           - backend:
@@ -25,24 +25,20 @@ spec:
             {{- else }}
               serviceName: {{ template "nexus.fullname" . }}
             {{- end }}
-{{- if .Values.nexusProxy.enabled }}
               servicePort: {{ .Values.nexusProxy.port }}
-{{- else }}
-              servicePort: {{ .Values.nexus.nexusPort }}
-{{- end }}
             path: {{ .Values.ingress.path }}
-{{- end }}
-  {{- with .Values.ingress.rules }}
+  {{- end }}
+  {{- with .Values.ingressDocker.rules }}
     {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-      {{- if .Values.nexusProxy.env.nexusHttpHost }}
-        - {{ .Values.nexusProxy.env.nexusHttpHost }}
+      {{- if .Values.nexusProxy.env.nexusDockerHost }}
+        - {{ .Values.nexusProxy.env.nexusDockerHost }}
       {{- end }}
-      {{- if .Values.ingress.tls.secretName }}
-      secretName: {{ .Values.ingress.tls.secretName | quote }}
+      {{- if .Values.ingressDocker.tls.secretName }}
+      secretName: {{ .Values.ingressDocker.tls.secretName | quote }}
       {{- end }}
 {{- end -}}
 {{- end }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -200,6 +200,28 @@ ingress:
   #         serviceName: additional-svc
   #         servicePort: 80
 
+ingressDocker:
+  enabled: false
+  path: /
+  labels: {}
+  annotations: {}
+  # # NOTE: Can't use 'false' due to https://github.com/jetstack/kube-lego/issues/173.
+  # kubernetes.io/ingress.allow-http: true
+  # kubernetes.io/ingress.class: gce
+  # kubernetes.io/ingress.global-static-ip-name: ""
+  # kubernetes.io/tls-acme: true
+  tls:
+    enabled: true
+    secretName: nexus-tls
+  # Specify custom rules in addition to or instead of the nexus-proxy rules
+  rules:
+  # - host: http://nexus.127.0.0.1.nip.io
+  #   http:
+  #     paths:
+  #     - backend:
+  #         serviceName: additional-svc
+  #         servicePort: 80
+
 
 tolerations: []
 


### PR DESCRIPTION
to provide configuration flexibility. Closes #96.

The split of ingress into http ingress and docker registry ingress is required to gain extra flexibility and allow separate configuration of ingresses. The configuration below allows to have extra hostnames for nexus http ingress and docker registry ingress.

```yaml
nexusProxy:
  env:
    nexusHttpHost: nexus.example.com
    nexusDockerHost: docker.example.com
ingress:
  enabled: true
  annotations:
    # workaround for https://github.com/helm/charts/issues/5385
    nginx.ingress.kubernetes.io/upstream-vhost: nexus.example.com
  rules:
    - host: nexus-extra.example.com
      http:
        paths:
          - backend:
              serviceName: nexus-sonatype-nexus
              servicePort: 8080
            path: /
ingressDocker:
  enabled: true
  annotations:
    # workaround for https://github.com/helm/charts/issues/5385
    nginx.ingress.kubernetes.io/upstream-vhost: docker.example.com
  rules:
    - host: docker-extra.example.com
      http:
        paths:
          - backend:
              serviceName: nexus-sonatype-nexus
              servicePort: 8080
            path: /
```