### PR TITLE
[charts/sonartype-nexus] includes env values of nexusBackup

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 3.0.0
+version: 3.1.0
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -134,6 +134,9 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexusBackup.imageTag`                      | Nexus backup image version          | `1.5.0`                                 |
 | `nexusBackup.imagePullPolicy`               | Backup image pull policy            | `IfNotPresent`                          |
 | `nexusBackup.env.targetBucket`              | Required if `nexusBackup` is enabled. Google Cloud Storage bucker for backups format `gs://BACKUP_BUCKET`  | `nil`  |
+| `nexusBackup.env.nexusAuthorization`        | If set, `nexusBackup.nexusAdminPassword` will be disregarded. | `nil`  |
+| `nexusBackup.env.offlineRepos`              | Space separated list of repositories must be taken down to achieve a consistent backup. | `"maven-central maven-public maven-releases maven-snapshots"`  |
+| `nexusBackup.env.gracePeriod`               | The amount of time in seconds to wait between stopping repositories and starting the upload. | `60`  |
 | `nexusBackup.nexusAdminPassword`            | Nexus admin password used by the backup container to access Nexus API. This password should match the one that gets chosen by the user to replace the default admin password after the first login  | `admin123`                |
 | `nexusBackup.persistence.enabled`           | Create a volume for backing Nexus configuration  | `true`                     |
 | `nexusBackup.persistence.accessMode`        | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                         |

--- a/charts/sonatype-nexus/templates/backup-secret.yaml
+++ b/charts/sonatype-nexus/templates/backup-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.nexusBackup.enabled }}
+{{- if and .Values.nexusBackup.enabled (not .Values.nexusBackup.env.nexusAuthorization) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -199,10 +199,14 @@ spec:
 {{ toYaml .Values.nexusBackup.resources | indent 12 }}
           env:
             - name: NEXUS_AUTHORIZATION
+            {{- if not .Values.nexusBackup.env.nexusAuthorization }}
               valueFrom:
                 secretKeyRef:
                   key: nexus.nexusAdminPassword
                   name: {{ template "nexus.fullname" . }}
+            {{- else }}
+              value: {{ .Values.nexusBackup.env.nexusAuthorization | quote }}
+            {{- end }}
             - name: NEXUS_BACKUP_DIRECTORY
               value: /nexus-data/backup
             - name: NEXUS_DATA_DIRECTORY
@@ -210,11 +214,11 @@ spec:
             - name: NEXUS_LOCAL_HOST_PORT
               value: "localhost:{{ .Values.nexus.nexusPort }}"
             - name: OFFLINE_REPOS
-              value: "maven-central maven-public maven-releases maven-snapshots"
+              value: {{ .Values.nexusBackup.env.offlineRepos | quote }}
             - name: TARGET_BUCKET
               value: {{ .Values.nexusBackup.env.targetBucket | quote }}
             - name: GRACE_PERIOD
-              value: "60"
+              value: {{ .Values.nexusBackup.env.gracePeriod | quote }}
             - name: TRIGGER_FILE
               value: .backup
           volumeMounts:

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -149,6 +149,9 @@ nexusBackup:
   imagePullPolicy: IfNotPresent
   env:
     targetBucket:
+    nexusAuthorization:
+    offlineRepos: "maven-central maven-public maven-releases maven-snapshots"
+    gracePeriod: 60
   nexusAdminPassword: "admin123"
   persistence:
     enabled: true


### PR DESCRIPTION
This PR enables the following variables of Nexus-Backup to receive custom values:
- `GRACE_PERIOD`
- `OFFLINE_REPOS`
- `NEXUS_AUTHORIZATION`

Although `NEXUS_AUTHORIZATION` is already set by the secret created with the value of `nexusBackup.nexusAdminPassword`, being able to set its value directly on a environment variable enables the use of secret manager such as HashiCorp Vault.