### PR TITLE
[charts/sonatype-nexus] feat: adds ClusterRoleBinding

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 3.1.1
+version: 3.2.0
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -181,6 +181,9 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `serviceAccount.create`                     | Automatically create a service account | `true`                               |
 | `serviceAccount.name`                       | Service account to use           | `nil`  |
 | `serviceAccount.annotations`                | Service account annotations  | `nil` |
+| `rbac.create`                               | Creates a ClusterRoleBinding attached to the Service account. | `false` |
+| `rbac.roleRef`                              | ClusterRoleBinding field `roleRef` content. See examples [here](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-example). | `nil` |
+| `rbac.annotations`                          | ClusterRoleBinding annotations.  | `nil` |
 | `route.enabled`         | Set to true to create route for additional service | `false` |
 | `route.name`            | Name of route                                      | `docker` |
 | `route.portName`        | Target port name of service                        | `docker` |

--- a/charts/sonatype-nexus/templates/clusterrolebinding.yaml
+++ b/charts/sonatype-nexus/templates/clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "nexus.fullname" . }}
+  labels:
+{{ include "nexus.labels" . | indent 4 }}
+{{- with .Values.rbac.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+roleRef:
+{{- with .Values.rbac.roleRef }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+subjects:
+- kind: ServiceAccount
+  {{- if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+  {{- else }}
+  name: {{ template "nexus.fullname" . }}
+  {{- end }}
+  namespace: {{ template "nexus.namespace" . }}
+{{- end -}}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -181,6 +181,11 @@ serviceAccount:
   name:
   annotations: {}
 
+rbac:
+  create: false
+  roleRef: {}
+  annotations: {}
+
 ingress:
   enabled: false
   path: /


### PR DESCRIPTION
ClusterRoleBinding is needed when some ClusterRole must be assigned to Pod's ServiceAccount in order to some integration works. For example, [vault mutating webhook](https://banzaicloud.com/docs/bank-vaults/mutating-webhook/) requires it.