### PR TITLE
[sonatype-nexus] Fix statefulset label issues

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 3.2.0
+version: 3.3.0
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/templates/_helpers.tpl
+++ b/charts/sonatype-nexus/templates/_helpers.tpl
@@ -36,13 +36,6 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "nexus.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
 Create a default fully qualified name for proxy keystore secret.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -54,7 +47,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "nexus.labels" -}}
 app: {{ template "nexus.name" . }}
 fullname: {{ template "nexus.fullname" . }}
-chart: {{ template "nexus.chart" . }}
+chart: {{ .Chart.Name }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
 {{- end -}}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -18,8 +18,8 @@ nexus:
   # Uncomment this to scheduler pods on priority
   # priorityClassName: "high-priority"
   env:
-    - name: install4jAddVmParams
-      value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+    - name: INSTALL4J_ADD_VM_PARAMS
+      value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:ActiveProcessorCount=4"
     - name: NEXUS_SECURITY_RANDOMPASSWORD
       value: "false"
   # nodeSelector:

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -60,7 +60,7 @@ nexus:
     fsGroup: 200
   podAnnotations: {}
   livenessProbe:
-    initialDelaySeconds: 30
+    initialDelaySeconds: 300
     periodSeconds: 30
     failureThreshold: 6
     # timeoutSeconds: 10


### PR DESCRIPTION
Closes #93 

As mentioned in that issue, having the version number in the labels for all the resources is problematic for StatefulSets and PVCs. This removes that version number and just uses the chart name instead which shouldn't change in future. Obviously this will cause one last breakage for affected users but future upgrades should be less painful.

Here is an example error I encountered when going from 3.1.1 to 3.2.0 of the Helm chart:
`cannot patch "sonatype-nexus" with kind StatefulSet: StatefulSet.apps "sonatype-nexus" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden`

The fix was to delete the StatefulSet and redeploy which isn't ideal.

In addition I've increased the default `initialDelaySeconds` for the livenessProbe to 5 minutes. With large repositories it can take a long time for nexus to start up where it does a `chown` to the nexus user on all files in the data volume. 30 seconds can cause a lot of unnecessary restarts.

Finally I've changed the `install4jAddVmParams` to `INSTALL4J_ADD_VM_PARAMS` which seems to be what the Nexus startup scripts are looking for. I've removed `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` because they don't make much sense when explicitly setting Xmx and Xms, and added `-XX:ActiveProcessorCount=4` which fixes https://github.com/travelaudience/docker-nexus/issues/27.

I'm very happy to make changes if you disagree with any of these. Thanks for the great Helm Chart :+1: 