### PR TITLE
Sonarqube: fix plugins download

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.1.1]
+* Update SonarQube to 8.5.1.
+* **Fix:** Purge plugins directory before download.
+
 ## [9.0.0]
 * Update SonarQube to 8.5.
 * **Breaking change:** Rework init containers.

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.1.0
-appVersion: 8.5-community
+version: 9.1.1
+appVersion: 8.5.1-community
 keywords:
   - coverage
   - security

--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -19,6 +19,7 @@ data:
     export no_proxy={{ .Values.plugins.noProxy }}
     {{- end }}
     {{- if .Values.plugins.install }}
+      rm {{ .Values.sonarqubeFolder }}/extensions/downloads/*
       {{ range $index, $val := .Values.plugins.install }}echo {{ $val | quote }} >> {{ $.Values.sonarqubeFolder }}/extensions/downloads/list{{ end }}
       cat {{ .Values.sonarqubeFolder }}/extensions/downloads/list | xargs -n 1 -P 8 wget --directory-prefix {{ .Values.sonarqubeFolder }}/extensions/downloads --no-verbose
       rm {{ .Values.sonarqubeFolder }}/extensions/downloads/list


### PR DESCRIPTION
Plugins download directory should be purged before downloading to avoid existing file error.