### PR TITLE
Configure GCP backup without deploying nexus itself to Google Cloud

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 3.4.0
+version: 3.5.0
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -148,6 +148,13 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexusBackup.persistence.annotations`       | PV annotations for backup           | `{}`                                    |
 | `nexusBackup.persistence.existingClaim`     | Existing PVC name for backup        | `nil`                                   |
 | `nexusBackup.resources`                     | Backup resource requests and limits | `{}`                                    |
+| `nexusCloudiam.enabled`                       | Nexus Cloud IAM service account key path                | `false`                                 |
+| `nexusCloudiam.persistence.accessMode`        | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                         |
+| `nexusCloudiam.persistence.annotations`       | PV annotations for Cloud IAM service account key path | `{}`                                    |
+| `nexusCloudiam.persistence.enabled`           | Create a volume for Cloud IAM service account key path  | `true`                     |
+| `nexusCloudiam.persistence.existingClaim`     | Existing PVC name for Cloud IAM service account key path        | `nil`                                   |
+| `nexusCloudiam.persistence.storageClass`      | Storage class of Cloud IAM service account path PVC   | `nil`                                   |
+| `nexusCloudiam.persistence.storageSize`       | Size of Cloud IAM service account path volume    | `8Gi`                                   |
 | `ingress.enabled`                           | Create an ingress for Nexus         | `false`                                  |
 | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
 | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -275,6 +275,47 @@ resources:
     memory: 4800Mi
 ```
 
+### Using GCP Storage for Backup
+
+Irrespective of whether Nexus is deployed to Google's GKE, or to some other k8s installation, it is possible to configure the [nexus-backup](https://github.com/travelaudience/docker-nexus-backup) container to backup to GCP Cloud Storage.
+This makes for a cost effective solution for backups.
+
+To enable, add the following key to the values file:
+
+```yaml
+nexusCloudiam:
+  enabled: true
+```
+
+You should also deploy Nexus as a stateful app, rather than a deployment.
+That means also adding:
+ 
+```yaml
+statefulset:
+  enabled: true
+```
+
+Deploying the chart now will result in a new PV and PVC within the pod that runs the containers.
+
+Create a service account with privileges to upload to your GCP bucket, and creaet a key for this service account.
+Download that service account key as a file, call it `service-account-key.json`.
+
+This file now needs to be made available to the pod running in k8s, and should be called `/nexus-data/cloudiam/service-account-key.json`.
+How this is done will depend upon the storage class used for the PV.
+
+Confirm that the service account file is available to the pod, using:
+ 
+    kubectl exec --stdin --tty \
+        --container nexus-backup \
+        sonatype-nexus-0 \
+        -- find /nexus-data/cloudiam -type f
+
+You might need to scale the deployment to zero and back up to pick up the changes:
+
+    kubectl scale --replicas=0 statefulset.apps/sonatype-nexus
+    kubectl scale --replicas=1 statefulset.apps/sonatype-nexus
+
+
 ## After Installing the Chart
 
 After installing the chart a couple of actions need still to be done in order to use nexus. Please follow the instructions below.

--- a/charts/sonatype-nexus/templates/cloudiam-pv.yaml
+++ b/charts/sonatype-nexus/templates/cloudiam-pv.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.nexusCloudiam.enabled (not .Values.statefulset.enabled) }}
+{{- if .Values.nexusCloudiam.persistence.pdName -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.nexusCloudiam.persistence.pdName }}
+  namespace: {{ template "nexus.namespace" . }}
+  labels:
+{{ include "nexus.labels" . | indent 4 }}
+spec:
+  capacity:
+    storage: {{ .Values.nexusCloudiam.persistence.storageSize }}
+  accessModes:
+    - ReadWriteOnce
+  claimRef:
+    name: {{ template "nexus.fullname" . }}-cloudiam
+    namespace: {{ .Release.Namespace }}
+  gcePersistentDisk:
+    pdName: {{ .Values.nexusCloudiam.persistence.pdName }}
+    fsType: {{ .Values.nexusCloudiam.persistence.fsType }}
+{{- end }}
+{{- end }}

--- a/charts/sonatype-nexus/templates/cloudiam-pvc.yaml
+++ b/charts/sonatype-nexus/templates/cloudiam-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.nexusCloudiam.enabled (not .Values.statefulset.enabled) }}
+{{- if and .Values.nexusCloudiam.persistence.enabled (not .Values.nexusCloudiam.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "nexus.fullname" . }}-cloudiam
+  namespace: {{ template "nexus.namespace" . }}
+  labels:
+{{ include "nexus.labels" . | indent 4 }}
+{{- if .Values.nexusCloudiam.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.nexusCloudiam.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.nexusCloudiam.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.nexusCloudiam.persistence.storageSize | quote }}
+{{- if .Values.nexusCloudiam.persistence.storageClass }}
+{{- if (eq "-" .Values.nexusCloudiam.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.nexusCloudiam.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -227,13 +227,17 @@ spec:
               value: .backup
             {{- if .Values.nexusCloudiam.enabled }}
             - name: CLOUD_IAM_SERVICE_ACCOUNT_KEY_PATH
-              value: /nexus-data/cloudiam
+              value: /nexus-data/cloudiam/service-account-key.json
             {{- end }}
           volumeMounts:
             - mountPath: /nexus-data
               name: {{ template "nexus.fullname" . }}-data
             - mountPath: /nexus-data/backup
               name: {{ template "nexus.fullname" . }}-backup
+            {{- if .Values.nexusCloudiam.enabled }}
+            - mountPath: /nexus-data/cloudiam
+              name: {{ template "nexus.fullname" . }}-cloudiam
+            {{- end }}
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 8 }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -119,6 +119,10 @@ spec:
             - mountPath: /nexus-data/backup
               name: {{ template "nexus.fullname" . }}-backup
             {{- end }}
+            {{- if .Values.nexusCloudiam.enabled }}
+            - mountPath: /nexus-data/cloudiam
+              name: {{ template "nexus.fullname" . }}-cloudiam
+            {{- end }}
             {{- if .Values.config.enabled }}
             - mountPath: {{ .Values.config.mountPath }}
               name: {{ template "nexus.name" . }}-conf
@@ -221,6 +225,10 @@ spec:
               value: {{ .Values.nexusBackup.env.gracePeriod | quote }}
             - name: TRIGGER_FILE
               value: .backup
+            {{- if .Values.nexusCloudiam.enabled }}
+            - name: CLOUD_IAM_SERVICE_ACCOUNT_KEY_PATH
+              value: /nexus-data/cloudiam
+            {{- end }}
           volumeMounts:
             - mountPath: /nexus-data
               name: {{ template "nexus.fullname" . }}-data
@@ -250,6 +258,10 @@ spec:
         - name: {{ template "nexus.fullname" . }}-backup
           emptyDir: {}
         {{- end }}
+        {{- if and .Values.nexusCloudiam.enabled (not .Values.nexusCloudiam.persistence.enabled) }}
+        - name: {{ template "nexus.fullname" . }}-cloudiam
+          emptyDir: {}
+        {{- end }}
         {{- else }}
         - name: {{ template "nexus.fullname" . }}-data
           {{- if .Values.persistence.enabled }}
@@ -263,6 +275,15 @@ spec:
           {{- if and .Values.nexusBackup.persistence.enabled .Values.nexusBackup.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.nexusBackup.persistence.existingClaim | default (printf "%s-%s" (include "nexus.fullname" .) "backup") }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.nexusCloudiam.enabled }}
+        - name: {{ template "nexus.fullname" . }}-cloudiam
+          {{- if and .Values.nexusCloudiam.persistence.enabled .Values.nexusCloudiam.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.nexusCloudiam.persistence.existingClaim | default (printf "%s-%s" (include "nexus.fullname" .) "cloudiam") }}
           {{- else }}
           emptyDir: {}
           {{- end }}
@@ -334,6 +355,29 @@ spec:
         storageClassName: ""
         {{- else }}
         storageClassName: "{{ .Values.nexusBackup.persistence.storageClass }}"
+        {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.nexusCloudiam.persistence.enabled }}
+    - metadata:
+        name: {{ template "nexus.fullname" . }}-cloudiam
+        labels:
+{{ include "nexus.labels" . | indent 10 }}
+        {{- if .Values.nexusCloudiam.persistence.annotations }}
+        annotations:
+{{ toYaml .Values.nexusCloudiam.persistence.annotations | indent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - {{ .Values.nexusCloudiam.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.nexusCloudiam.persistence.storageSize | quote }}
+        {{- if .Values.nexusCloudiam.persistence.storageClass }}
+        {{- if (eq "-" .Values.nexusCloudiam.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.nexusCloudiam.persistence.storageClass }}"
         {{- end }}
         {{- end }}
     {{- end }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -191,7 +191,7 @@ nexusCloudiam:
     accessMode: ReadWriteOnce
     # See comment above for information on setting the backup storageClass
     # storageClass: "-"
-    storageSize: 4K
+    storageSize: 1Mi
     # If PersistentDisk already exists you can create a PV for it by including the 2 following keypairs.
     # pdName: nexus-cloudiam-path
     # fsType: ext4

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -181,6 +181,21 @@ nexusBackup:
       # cpu: 200m
       # memory: 512Mi
 
+nexusCloudiam:
+  enabled: false
+  persistence:
+    enabled: true
+    # existingClaim:
+    # annotations:
+    #  "helm.sh/resource-policy": keep
+    accessMode: ReadWriteOnce
+    # See comment above for information on setting the backup storageClass
+    # storageClass: "-"
+    storageSize: 4K
+    # If PersistentDisk already exists you can create a PV for it by including the 2 following keypairs.
+    # pdName: nexus-cloudiam-path
+    # fsType: ext4
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>uk.co.haywood-associates</groupId>
+    <artifactId>charts</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+</project>


### PR DESCRIPTION
Since travelaudience's Nexus-Backup container just needs a service account key file to be provided to it, this pull request sets up a PV/PVC called "/nexus-data/cloudiam", and sets up the $CLOUD_IAM_SERVICE_ACCOUNT_KEY_PATH to point to a file "service-account-key.json" in that directory.