### PR TITLE
fix: Docker ingress should work without proxy enable

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 3.4.0
+version: 3.4.1
 appVersion: 3.25.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/templates/ingress-docker.yaml
+++ b/charts/sonatype-nexus/templates/ingress-docker.yaml
@@ -28,9 +28,8 @@ spec:
 {{- if .Values.nexusProxy.enabled }}
               servicePort: {{ .Values.nexusProxy.port }}
 {{- else }}
-              servicePort: {{ .Values.nexus.nexusPort }}
+              servicePort: {{ .Values.nexus.dockerPort }}
 {{- end }}
-              servicePort: {{ .Values.nexusProxy.port }}
             path: {{ .Values.ingress.path }}
   {{- end }}
   {{- with .Values.ingressDocker.rules }}

--- a/charts/sonatype-nexus/templates/ingress-docker.yaml
+++ b/charts/sonatype-nexus/templates/ingress-docker.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingressDocker.enabled .Values.nexusProxy.enabled }}
+{{- if .Values.ingressDocker.enabled -}}
 apiVersion: {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }} networking.k8s.io/v1beta1 {{- else }} extensions/v1beta1 {{- end }}
 kind: Ingress
 metadata:
@@ -25,6 +25,11 @@ spec:
             {{- else }}
               serviceName: {{ template "nexus.fullname" . }}
             {{- end }}
+{{- if .Values.nexusProxy.enabled }}
+              servicePort: {{ .Values.nexusProxy.port }}
+{{- else }}
+              servicePort: {{ .Values.nexus.nexusPort }}
+{{- end }}
               servicePort: {{ .Values.nexusProxy.port }}
             path: {{ .Values.ingress.path }}
   {{- end }}


### PR DESCRIPTION
When proxy is not enable it is not possible to enable the ingress Docker if
needed

Signed-off-by: Kevin Lefevre <lefevre.kevin@gmail.com>
