### PR TITLE
Force remove extensions before they are installed in sonarqube

### DIFF
--- a/charts/sonarqube/templates/install-plugins.yaml
+++ b/charts/sonarqube/templates/install-plugins.yaml
@@ -19,7 +19,7 @@ data:
     export no_proxy={{ .Values.plugins.noProxy }}
     {{- end }}
     {{- if .Values.plugins.install }}
-      [ -e {{ .Values.sonarqubeFolder }}/extensions/downloads/* ] && rm {{ .Values.sonarqubeFolder }}/extensions/downloads/*
+      [ -e {{ .Values.sonarqubeFolder }}/extensions/downloads/* ] && rm -f {{ .Values.sonarqubeFolder }}/extensions/downloads/*
       {{ range $index, $val := .Values.plugins.install }}
       echo {{ $val | quote }} >> {{ $.Values.sonarqubeFolder }}/extensions/downloads/list{{ end }}
       cat {{ .Values.sonarqubeFolder }}/extensions/downloads/list | xargs -n 1 -P 8 wget --directory-prefix {{ .Values.sonarqubeFolder }}/extensions/downloads --no-verbose


### PR DESCRIPTION
Before the plugins are installed the previous downloads are removed from the downloads directory.
When there are no previously installed plugins, the remove command fails.
By adding the -f flag the rm command no longer fails if there are not files to remove.
Fix #206