### PR TITLE
work_with_openshift

### DIFF
--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -59,6 +59,12 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
+        - name: "wait-for-db"
+          image: {{ default "busybox:1.32" .Values.initContainers.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy  }}
+          resources:
+{{ toYaml .Values.initContainers.resources | indent 12 }}
+          command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]      
       {{- if .Values.caCerts }}
         - name: ca-certs
           image: {{ default "adoptopenjdk/openjdk11:alpine" .Values.caCerts.image }}
@@ -77,27 +83,6 @@ spec:
               subPath: certs
             - mountPath: /tmp/secrets/ca-certs
               name: ca-certs
-          {{- with .Values.env }}
-          env:
-            {{- . | toYaml | trim | nindent 12 }}
-          {{- end }}
-      {{- end }}
-      {{- if or .Values.initSysctl.enabled .Values.elasticsearch.configureNode }}
-        - name: init-sysctl
-          image: {{ default "busybox:1.32" .Values.initSysctl.image }}
-          imagePullPolicy: {{ .Values.image.pullPolicy  }}
-          {{- if $securityContext := (default .Values.initContainers.securityContext .Values.initSysctl.securityContext) }}
-          securityContext:
-{{ toYaml $securityContext | indent 12 }}
-          {{- end }}
-          resources:
-{{ toYaml (default .Values.initContainers.resources .Values.initSysctl.resources) | indent 12 }}
-          command: ["sh",
-            "-e",
-            "/tmp/scripts/init_sysctl.sh"]
-          volumeMounts:
-            - name: init-sysctl
-              mountPath: /tmp/scripts/
           {{- with .Values.env }}
           env:
             {{- . | toYaml | trim | nindent 12 }}
@@ -321,12 +306,6 @@ spec:
         secret:
           secretName: {{ .Values.caCerts.secret }}
       {{- end }}
-      - name: init-sysctl
-        configMap:
-          name: {{ template "sonarqube.fullname" . }}-init-sysctl
-          items:
-            - key: init_sysctl.sh
-              path: init_sysctl.sh
       - name: install-plugins
         configMap:
           name: {{ template "sonarqube.fullname" . }}-install-plugins

--- a/charts/sonarqube/templates/job.yaml
+++ b/charts/sonarqube/templates/job.yaml
@@ -1,0 +1,57 @@
+{{- if or .Values.initSysctl.enabled .Values.elasticsearch.configureNode }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sonarqube.fullname" . }}
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "sonarqube.name" . }}-{{ template "sonarqube.fullname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: sonarqube
+    app.kubernetes.io/component: {{ template "sonarqube.fullname" . }}
+    app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+spec:
+  template:
+    spec:
+    {{- if .Values.initSysctl.serviceAccount.create }}
+    {{- if .Values.initSysctl.serviceAccount.name }}
+      serviceAccountName: {{ .Values.initSysctl.serviceAccount.name }}
+    {{- else }}
+      serviceAccountName: {{ include "sonarqube.fullname" . }}-initsysctl
+    {{- end }}
+    {{- end }}   
+      containers:      
+      - name: init-sysctl
+        image: {{ default "busybox:1.32" .Values.initSysctl.image }}
+        imagePullPolicy: {{ .Values.image.pullPolicy  }}
+        {{- if $securityContext := (default .Values.initContainers.securityContext .Values.initSysctl.securityContext) }}
+        securityContext:
+{{ toYaml $securityContext | indent 12 }}
+        {{- end }}
+        resources:
+{{ toYaml (default .Values.initContainers.resources .Values.initSysctl.resources) | indent 12 }}
+        command: ["sh",
+          "-e",
+          "/tmp/scripts/init_sysctl.sh"]
+        volumeMounts:
+          - name: init-sysctl
+            mountPath: /tmp/scripts/
+        {{- with .Values.env }}
+        env:
+          {{- . | toYaml | trim | nindent 12 }}
+        {{- end }}
+      restartPolicy: {{ .Values.initSysctl.job.restartPolicy }}
+      volumes:
+        - name: init-sysctl
+          configMap:
+            name: {{ template "sonarqube.fullname" . }}-init-sysctl
+            items:
+              - key: init_sysctl.sh
+                path: init_sysctl.sh
+
+{{- end }}

--- a/charts/sonarqube/templates/serviceaccount-initsysctl.yaml
+++ b/charts/sonarqube/templates/serviceaccount-initsysctl.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.initSysctl.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{- if .Values.initSysctl.serviceAccount.name }}
+  name: {{ .Values.initSysctl.serviceAccount.name }}
+{{- else  }}
+  name: {{ include "sonarqube.fullname" . }}-initsysctl
+{{- end }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/charts/sonarqube/templates/sonarqube-init-scc.yaml
+++ b/charts/sonarqube/templates/sonarqube-init-scc.yaml
@@ -1,0 +1,58 @@
+{{- if and (.Values.OpenShift.enabled) (.Values.OpenShift.createSCC) }}
+{{- if and (.Values.initSysctl.serviceAccount.create) (not .Values.initSysctl.serviceAccount.name) }}
+
+# This SCC allows any user ID except root
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: "allows pod to run as root, privileged and run sysctl"
+    "helm.sh/hook": pre-install
+  name: {{ .Release.Name }}-initsysctl-privileged-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: true
+allowPrivilegeEscalation: true
+allowedCapabilities: []
+allowedFlexVolumes: []
+allowedUnsafeSysctls: []
+defaultAddCapabilities: []
+defaultAllowPrivilegeEscalation: true
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: RunAsAny
+# This can be customized for your host machine
+seLinuxContext:
+  type: MustRunAs
+# seLinuxOptions:
+#   level:
+#   user:
+#   role:
+#   type:
+supplementalGroups:
+  type: RunAsAny
+# This can be customized for your host machine
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+# If you want a priority on your SCC -- set for a value more than 0
+priority: 11
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-sonarqube-initsysctl
+
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/sonarqube-scc.yaml
+++ b/charts/sonarqube/templates/sonarqube-scc.yaml
@@ -1,0 +1,65 @@
+{{- if and (.Values.OpenShift.enabled) (.Values.OpenShift.createSCC) }}
+
+# This SCC allows any user ID except root
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: "nonroot provides all features of the restricted SCC
+      but allows users to run with any non-root UID.  The user must specify the UID
+      or it must be specified on the by the manifest of the container runtime."
+    "helm.sh/hook": pre-install
+  name: {{ .Release.Name }}-nonroot-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: true
+allowedCapabilities: []
+allowedFlexVolumes: []
+allowedUnsafeSysctls: []
+defaultAddCapabilities: []
+defaultAllowPrivilegeEscalation: true
+forbiddenSysctls:
+  - "*"
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+# This can be customized for your host machine
+seLinuxContext:
+  type: MustRunAs
+# seLinuxOptions:
+#   level:
+#   user:
+#   role:
+#   type:
+supplementalGroups:
+  type: RunAsAny
+# This can be customized for your host machine
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+# If you want a priority on your SCC -- set for a value more than 0
+priority: 11
+users:
+{{- if .Values.serviceAccount.name }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-{{ .Values.serviceAccount.name }}
+{{- else  }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-sonarqube
+{{- end }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-postgresql
+
+{{- end }}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -13,6 +13,11 @@ deploymentStrategy: {}
 ##
 # schedulerName:
 
+## Is this deployment for OpenShift? If so, we help with SCCs
+OpenShift:
+  enabled: false
+  createSCC: true
+
 image:
   repository: sonarqube
   tag: 8.5-community
@@ -22,7 +27,9 @@ image:
 
 # Set security context for sonarqube pod
 securityContext:
-  fsGroup: 999
+  fsGroup: 1000
+  #Sonarqube dockerfile creates sonarqube user as UID and GID 1000
+  runAsUser: 1000
 
 # Settings to configure elasticsearch host requirements
 elasticsearch:
@@ -127,9 +134,14 @@ initSysctl:
   nofile: 131072
   nproc: 8192
   # image: busybox:1.32
+  serviceAccount:
+    create: false
+  # name:
   securityContext:
     privileged: true
   # resources: {}
+  job:
+    restartPolicy: OnFailure
 
 # List of plugins to install.
 # For example:
@@ -243,6 +255,37 @@ postgresql:
   # Specify the TCP port that PostgreSQL should use
   service:
     port: 5432
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 20Gi
+    storageClass:      
+  securityContext:
+    # enabled needs to false for OpenShift restricted SCC and true for OpenShift anyuid/nonroot SCC
+    enabled: true
+    #fsGroup and runAsUser specifications below are not applied if enabled=false. enabled=false is the required setting for OpenShift "restricted SCC" to work successfully.
+    #postgresql dockerfile sets user as 1001
+    fsGroup: 1001
+    runAsUser: 1001
+  volumePermissions:
+    enabled: true
+    # if using restricted SCC set runAsUser: "auto" and if running under anyuid/nonroot SCC - runAsUser needs to match runAsUser above
+    securityContext:
+      runAsUser: 1001
+  shmVolume:
+    chmod:
+      enabled: false
+  serviceAccount:
+    ## If enabled = true, and name is not set, postgreSQL will create a serviceAccount
+    enabled: false
+#    name:
 
 # Additional labels to add to the pods:
 # podLabels:


### PR DESCRIPTION
Hi, I've been reworking this chart to function in an OpenShift cluster. The changes look to do a number of things:

- Auto-create SCCs for postgreSQL and SonarQube (equiv to nonroot)
- Split the init-sysctl container into a job and provide it with serviceAccount and access to a "stripped-down" privileged SCC

I've got it working on my cluster with:
```
helm install <release_name> . --set serviceAccount.create=true,postgresql.serviceAccount.enabled=true,OpenShift.enabled=true,OpenShift.createSCC=true,initSysctl.serviceAccount.create=true
```

This uses a key in values.yaml (`OpenShift.enabled`) to assert whether OpenShift SCC resources need to be created.

I've also:
- exposed some additional postgreSQL keys in values.yaml
- added an initContainer to monitor postgreSQL is up before starting SonarQube.

Just wanted to see if there is any interest in this, and any validation you'd like to apply. My only concern at the moment is that the job to perform the `systctl` changes will happen once on the worker node this is deployed to, but then wouldn't happen again if the sonarqube pod was recreated on a new worker node. I think a `daemonset` could be used to apply the `sysctl` command to all/specific labelled worker nodes.