### PR TITLE
Fix Port from 8080 to 8081

### DIFF
--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -100,8 +100,8 @@ nexusProxy:
   imageName: quay.io/travelaudience/docker-nexus-proxy
   imageTag: 2.6.0
   imagePullPolicy: IfNotPresent
-  port: 8080
-  targetPort: 8080
+  port: 8081
+  targetPort: 8081
   # labels: {}
   env:
     nexusDockerHost:


### PR DESCRIPTION
Nexusproxy proxies to port 8080 but nexus runs by default on 8081 also earlier in this file port is set to 8081.