### PR TITLE
Add custom terminationgraceperiodseconds

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 4.0.0
+version: 4.0.1
 appVersion: 3.27.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -109,6 +109,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.failureThreshold`     | Number of attempts before failure   | 6                                       |
 | `nexus.readinessProbe.timeoutSeconds`       | Time in seconds after readiness probe times out    | `nil`                    |
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
+| `nexus.terminationGracePeriodSeconds`       | Let Nexus terminate gracefully      | 120                                     |
 | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
 | `nexus.context`                             | Non-root path to run Nexus at       | `nil`                                   |
 | `nexusProxy.enabled`                        | Enable nexus proxy                  | `true`                                  |

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -317,6 +317,7 @@ spec:
         {{- if .Values.deployment.additionalVolumes }}
 {{ toYaml .Values.deployment.additionalVolumes | indent 8 }}
         {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.nexus.terminationGracePeriodSeconds }}
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -85,7 +85,7 @@ nexus:
   #   - "example.com"
   #   - "www.example.com"
   context:
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 120
 
 route:
   enabled: false

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -85,6 +85,7 @@ nexus:
   #   - "example.com"
   #   - "www.example.com"
   context:
+  terminationGracePeriodSeconds: 30
 
 route:
   enabled: false


### PR DESCRIPTION
Customizing terminationgraceperiodseconds maybe helpful to prevent Orientdb corruption during an stop/start action ( eg : upgrade )