### PR TITLE
Add affinity labels allow the use of this K8s feature.

### DIFF
--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -321,6 +321,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 
 
 ## create pvc in case of statefulsets

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -264,6 +264,7 @@ ingressDocker:
   #         serviceName: additional-svc
   #         servicePort: 80
 
+affinity: {}
 
 tolerations: []
 


### PR DESCRIPTION
Add affinity labels in values.yaml and deployment-statefulset.yaml allow the use of this K8s feature.
Node affinity allows you to constrain which nodes your pod is eligible to be scheduled on, based on labels on the node.
