### PR TITLE
Add nexus.chownNexusData parameter

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 4.1.0
+version: 4.1.1
 appVersion: 3.27.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -111,6 +111,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
 | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
 | `nexus.context`                             | Non-root path to run Nexus at       | `nil`                                   |
+| `nexus.chownNexusData`                      | Set false to not execute chown to the mounted nexus-data directory at startup | `true` |
 | `nexusProxy.enabled`                        | Enable nexus proxy                  | `true`                                  |
 | `nexusProxy.svcName`                        | Nexus proxy service name            | `nil`                                  |
 | `nexusProxy.targetPort`                     | Container Port for Nexus proxy      | `8080`                                  |

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -84,6 +84,10 @@ spec:
             - name: NEXUS_CONTEXT
               value: {{ .Values.nexus.context }}
 {{- end }}
+{{- if .Values.nexus.chownNexusData }}
+            - name: NEXUS_DATA_CHOWN
+              value: {{ .Values.nexus.chownNexusData }}
+{{- end }}
 
           resources:
 {{ toYaml .Values.nexus.resources | indent 12 }}

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -86,7 +86,7 @@ spec:
 {{- end }}
 {{- if .Values.nexus.chownNexusData }}
             - name: NEXUS_DATA_CHOWN
-              value: {{ .Values.nexus.chownNexusData }}
+              value: {{ .Values.nexus.chownNexusData | quote }}
 {{- end }}
 
           resources:

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -85,6 +85,9 @@ nexus:
   #   - "example.com"
   #   - "www.example.com"
   context:
+  # When using nexus it is important that all the files in the data directory have the proper owner configured. Therefore this
+  # value defaults to true to apply chown -R nexus:nexus to the mounted directory at every startup of the container.
+  chownNexusData: true
 
 route:
   enabled: false


### PR DESCRIPTION
I introduced a new parameter called nexus.chownNexusData.

When the docker-nexus container starts it executes the following file /etc/service/nexus/run which does the following:

```
#!/bin/sh

if [ "$NEXUS_DATA_CHOWN" == "true" ]; then
    chown -R nexus:nexus /opt/sonatype
    chown -R nexus:nexus /nexus-data
fi
```

As you can see when the environment variable NEXUS_DATA_CHOWN is set (Default: true, https://github.com/travelaudience/docker-nexus/blob/5c386f3e2154decbf5e521714fc9b8f204b873a4/Dockerfile#L23) . 
The owner for the full /opt/sonatype and /nexus-data directory is set. This behaviour is fine as long as the amount of artifacts is not too large. Unfortunately, in our case we have quite a large amount of artifacts which would lead to startup times of close to 45 minutes but before that the readiness probe obviously kills the container. Therefore, it is stuck in an endless loop of trying to change the owner of all files over and over again. Additionally, in our case we don't have any issues with file permissions in our mounted k8s volumes, making the step of modifying the owner at every container startup unnecessary.