### PR TITLE
arbitrary ports to deployment-statefulsets

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 4.1.1
+version: 4.1.2
 appVersion: 3.27.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -93,6 +93,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.resources`                           | Nexus resource requests and limits  | `{}`                                    |
 | `nexus.dockerPort`                          | Port to access docker               | `5003`                                  |
 | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |
+| `nexus.additionalPorts`                     | expose additional ports             | `[]`                                  |
 | `nexus.service.type`                        | Service for Nexus                   | `NodePort`                                |
 | `nexus.service.clusterIp`                   | Specific cluster IP when service type is cluster IP. Use None for headless service |`nil`   |
 | `nexus.service.loadBalancerIP`                        | Custom loadBalancerIP                   |`nil`                                |

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -95,7 +95,10 @@ spec:
             - containerPort: {{ .Values.nexus.dockerPort }}
               name: nexus-docker-g
             - containerPort: {{ .Values.nexus.nexusPort }}
-              name: nexus-http
+              name: nexus-http        
+            {{- with .Values.nexus.additionalPorts  }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.nexus.livenessProbe.path }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -46,6 +46,7 @@ nexus:
   # The ports should only be changed if the nexus image uses a different port
   dockerPort: 5003
   nexusPort: 8081
+  additionalPorts: []
   service:
     type: NodePort
     # clusterIP: None


### PR DESCRIPTION
This PR adds support for arbitrary ports setup on the deployment/statefulset.
This is useful in cases like the one described at https://blog.sonatype.com/using-nexus-3-as-your-repository-part-3-docker-images where it's required to use more ports than the one available by setting the value `nexus.dockerPort`.

Solves #132 