### PR TITLE
sonarqube: fix #250

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.3.0
+version: 9.3.1
 appVersion: 8.5.1-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -266,9 +266,15 @@ spec:
             - mountPath: {{ .Values.sonarqubeFolder }}/data
               name: sonarqube
               subPath: data
+            {{- if .Values.persistence.enabled }}
             - mountPath: {{ .Values.sonarqubeFolder }}/extensions
               name: sonarqube
               subPath: extensions
+            {{- else if .Values.plugins.install }}
+            - mountPath: {{ .Values.sonarqubeFolder }}/extensions/downloads
+              name: sonarqube
+              subPath: extensions/downloads
+            {{- end }}
             {{- if .Values.plugins.lib }}
             {{- range $index, $val := .Values.plugins.lib }}
             - mountPath: {{ $.Values.sonarqubeFolder }}/lib/common/{{ $val }}


### PR DESCRIPTION
Restore plugin directory mount behaviour as in v9.2.6 and before, in case of no persistence enabled.
