### PR TITLE
Add a default backend for GCE ingress controller

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.5.0]
+* Add Ingress default backend for GCE class
+
 ## [9.2.3]
 * Added namespace to port-foward command in notes.
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.4.1
+version: 9.5.0
 appVersion: 8.5.1-community
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -45,9 +45,29 @@ kindly-newt 1           Mon Oct  2 15:05:44 2017    DEPLOYED    sonarqube-0.1.0 
 $ helm delete kindly-newt
 ```
 
-## Ingress Paths
+## Ingress
 
+### Path
 Some cloud may need the path to be /* instead of /. Try this first if you are having issues getting traffic through the ingress.
+
+### Default Backend
+
+if you use GCP as a cloud provider you need to set a default backend to avoid useless default backend created by the gce controller. To add this default backend you must set "ingress.class" annotation with "gce" or "gce-internal" value.
+
+Example:
+
+```yaml
+...
+ingress:
+  enabled: true
+  hosts:
+    - name: sonarqube.example.com
+      path: "/*"
+  annotations:
+    kubernetes.io/ingress.class: "gce-internal"
+    kubernetes.io/ingress.allow-http: "false"
+...
+```
 
 ## Configuration
 

--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -24,12 +24,13 @@ metadata:
     {{- end }}
 {{- end }}
 spec:
-  {{- if .Values.ingress.annotations}}
+  {{- if .Values.ingress.annotations }}
   {{- range $key, $value := .Values.ingress.annotations }}
   {{- if and (eq $key "kubernetes.io/ingress.class") (contains $value "gce") }}
   backend:
     serviceName: {{ default $serviceName .serviceName }}
     servicePort: {{ default $servicePort .servicePort }}
+  {{- end }}
   {{- end }}
   {{- end }}
   rules:

--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -24,6 +24,14 @@ metadata:
     {{- end }}
 {{- end }}
 spec:
+  {{- if .Values.ingress.annotations}}
+  {{- range $key, $value := .Values.ingress.annotations }}
+  {{- if and (eq $key "kubernetes.io/ingress.class") (contains $value "gce") }}
+  backend:
+    serviceName: {{ default $serviceName .serviceName }}
+    servicePort: {{ default $servicePort .servicePort }}
+  {{- end }}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .name }}


### PR DESCRIPTION
if you use GCP as a cloud provider you need to set a default backend to avoid useless default backend created by the gce controller. To add this default backend you must set "ingress.class" annotation with "gce" or "gce-internal" value. 

I haven't managed Kubernetes or AWS workaround because I don't know if it is needed (and i'm not aware about those platform)

Let me know if my statements will work as is.