### PR TITLE
sonatype-nexus: add custom TLS hosts configuration to ingress

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 4.3.0
+version: 4.3.1
 appVersion: 3.27.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -165,6 +165,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
 | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |
 | `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
+| `ingress.tls.hosts`                    | Custom TLS hosts configuration | `{}`                             |
 | `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
 | `ingressDocker.enabled`                           | Create an ingress for Docker registry         | `false`                                  |
 | `ingressDocker.annotations`                       | Annotations to enhance docker ingress configuration  | `{}`                          |

--- a/charts/sonatype-nexus/templates/ingress.yaml
+++ b/charts/sonatype-nexus/templates/ingress.yaml
@@ -44,5 +44,8 @@ spec:
       {{- if .Values.ingress.tls.secretName }}
       secretName: {{ .Values.ingress.tls.secretName | quote }}
       {{- end }}
+  {{- with .Values.ingress.tls.hosts }}
+    {{- toYaml . | nindent 4 }}
+  {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -227,7 +227,7 @@ rbac:
   annotations: {}
 
 ingress:
-  enabled: true
+  enabled: false
   path: /
   labels: {}
   annotations: {}

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -227,7 +227,7 @@ rbac:
   annotations: {}
 
 ingress:
-  enabled: false
+  enabled: true
   path: /
   labels: {}
   annotations: {}
@@ -239,6 +239,7 @@ ingress:
   tls:
     enabled: true
     secretName: nexus-tls
+    hosts:
   # Specify custom rules in addition to or instead of the nexus-proxy rules
   rules:
   # - host: http://nexus.127.0.0.1.nip.io


### PR DESCRIPTION
It's nice to have a custom TLS hosts configuration as an addition to the custom ingress rules.