### PR TITLE
Add support for setting custom annotations in admin hook job

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,6 +1,9 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
 
+## [9.6.1]
+* Add support for setting custom annotations in admin hook job.
+
 ## [9.6.0]
 * Add the possibility of definining the secret key name of the postgres password.
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.6.0
+version: 9.6.1
 appVersion: 8.5.1-community
 keywords:
   - coverage

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -193,6 +193,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `account.adminPassword`                                  | Custom admin password                                                                                                     | `"admin"`                       |
 | `account.currentAdminPassword`                           | Current admin password                                                                                                    | `"admin"`                       |
 | `curlContainerImage`                                     | Curl container image                                                                                                      | `"curlimages/curl:latest"`      |
+| `adminJobAnnotations`                                    | Custom annotations for admin hook Job                                                                                     | `{}`                            |
 | `terminationGracePeriodSeconds`                          | Configuration of `terminationGracePeriodSeconds`                                                                          | `60`                            |
 
 You can also configure values for the PostgreSQL database via the Postgresql [Chart](https://hub.helm.sh/charts/bitnami/postgresql)

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -15,6 +15,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded
+  {{- range $key, $value := .Values.adminJobAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -357,5 +357,6 @@ extraConfig:
 #   adminPassword: admin
 #   currentAdminPassword: admin
 # curlContainerImage: curlimages/curl:latest
+# adminJobAnnotations: {}
 
 terminationGracePeriodSeconds: 60


### PR DESCRIPTION
Hi!

I would like to add support for adding annotations to the admin hook job, since there are container injection services like Istio, whose way to enable / disable them is through annotations.

Regards!