### PR TITLE
GH-277, URL escape admin passwords in change-admin-password-hook job

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
+## [9.6.3]
+* Fixed GH-277 by ensuring current/new admin passwords are URL escaped in the change-admin-password-hook job.
+
 ## [9.6.2]
 * Change order of env variables to better support 7.9-lts
 
@@ -42,6 +45,6 @@ All changes to this chart will be documented in this file.
 * Rework sysctl with support for custom values.
 * Rework plugins installation via `opt/sonarqube/extensions/downloads` folder that is handled by SonarQube itself.
     * **Breaking change:** remove `plugins.deleteDefaultPlugins` as SonarQube stores bundled plugins out of `opt/sonarqube/extensions`.
-* Rename deprecated `SONARQUBE_` environment variables to `SONAR_` ones. 
+* Rename deprecated `SONARQUBE_` environment variables to `SONAR_` ones.
 * **Breaking change:** Rename `enabledTests` to `tests.enabled`.
 * Add `terminationGracePeriodSeconds`.

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.6.2
+version: 9.6.3
 appVersion: 8.5.1-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/change-admin-password-hook.yml
+++ b/charts/sonarqube/templates/change-admin-password-hook.yml
@@ -34,6 +34,6 @@ spec:
       containers:
       - name: {{ template "sonarqube.fullname" . }}-change-default-admin-password
         image: {{ default "curlimages/curl:latest" .Values.curlContainerImage }}
-        command: ["sh", "-c", 'until curl -v --connect-timeout 100 {{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}/api/system/status | grep -w UP; do sleep 10; done; curl -v --connect-timeout 100 -u admin:{{ default "admin" .Values.account.currentAdminPassword }} -X POST "{{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}/api/users/change_password?login=admin&previousPassword={{ default "admin" .Values.account.currentAdminPassword }}&password={{ default "admin" .Values.account.adminPassword }}"']
+        command: ["sh", "-c", 'until curl -v --connect-timeout 100 {{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}/api/system/status | grep -w UP; do sleep 10; done; curl -v --connect-timeout 100 -u admin:{{ default "admin" .Values.account.currentAdminPassword }} -X POST "{{ template "sonarqube.fullname" . }}:{{ default 9000 .Values.service.internalPort }}/api/users/change_password?login=admin&previousPassword={{ .Values.account.currentAdminPassword | default "admin" | urlquery }}&password={{ .Values.account.adminPassword | default "admin" | urlquery }}"']
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes GH-277 by using the `urlquery` helm function with the current/net admin password in the change-admin-password-hook job