### PR TITLE
Fix/ Nexus Chart - ocp route targetportname

### DIFF
--- a/charts/sonatype-nexus/templates/route.yaml
+++ b/charts/sonatype-nexus/templates/route.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   host: {{ .Values.route.path }}
   port:
-    targetPort: {{ .Values.service.portName }}
+    targetPort: {{ .Values.route.portName }}
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -99,7 +99,7 @@ route:
   portName: docker
   labels:
   annotations:
-  # path: /docker
+  # path: docker.apps.ocp01.cluster.local
 
 nexusProxy:
   enabled: true


### PR DESCRIPTION
The target port used in the route resource are adjusted to use the route.portName var instead the service one (that have errors to bake the chart)

The values.yaml file, have an route example that have some DNS errors with the compliance
Included one example, with ocp.cluster.local (base dns to be adjusted)