### PR TITLE
fix: create svc endpoints for additionalPorts

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 5.1.1
+version: 5.1.2
 appVersion: 3.27.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/templates/proxy-svc.yaml
+++ b/charts/sonatype-nexus/templates/proxy-svc.yaml
@@ -41,6 +41,12 @@ spec:
       name: docker
       protocol: TCP
       targetPort: {{ .Values.nexus.dockerPort }}
+{{- range $ports := .Values.nexus.additionalPorts }}
+    - port: {{ $port.containerPort }}
+      name: {{ $port.name }}
+      protocol: TCP
+      targetPort: {{ $port.containerPort }}
+{{- end }}
 {{- end }}
   selector:
     app: {{ template "nexus.name" . }}


### PR DESCRIPTION
Currently service endpoints are not created for the Nexus additionalPorts. This PR purposed to fix it.