### PR TITLE
Add securityContext to wait-for-db initContainer like the other initContainers

### DIFF
--- a/charts/sonarqube/CHANGELOG.md
+++ b/charts/sonarqube/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SonarQube Chart Changelog
 All changes to this chart will be documented in this file.
+## [9.x.x]
+* Use the `initContainers.securityContext` to also set the security context of the `wait-for-db` init container.
+
 ## [9.6.3]
 * Fixed GH-277 by ensuring current/new admin passwords are URL escaped in the change-admin-password-hook job.
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.6.4
+version: 9.6.5
 appVersion: 8.5.1-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -168,6 +168,10 @@ spec:
         - name: "wait-for-db"
           image: {{ default "busybox:1.32" .Values.initContainers.image }}
           imagePullPolicy: {{ .Values.image.pullPolicy  }}
+          {{- if $securityContext := .Values.initContainers.securityContext }}
+          securityContext:
+{{ toYaml $securityContext | indent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.initContainers.resources | indent 12 }}
           command: ["/bin/sh", "-c", "for i in $(seq 1 200); do nc -z -w3 {{ .Release.Name}}-postgresql 5432 && exit 0 || sleep 2; done; exit 1"]


### PR DESCRIPTION
### Sonarqube Helm Chart
Actually the `initContainer.securityContext` value set all the securityContext for all containers except the 'wait-for-db' one.
This PR simply set the securityContext to the 'wait-for-db' initContainer the same way than the other initContainers.

It may be considered as a breaking change as it can break the wait-for-db initContainer depending on what people specified in the `initContainer.securityContext` already.  

If you prefer, I can also add a new value in `values.yaml` file to set the wait-for-db securityContext (something like `waitForDb.securityContext`). 
IMO normalization is always better. But the decision is yours.