### PR TITLE
[sonatype-nexus] Improve ingress tls hosts configuration

### DIFF
--- a/charts/sonatype-nexus/templates/ingress.yaml
+++ b/charts/sonatype-nexus/templates/ingress.yaml
@@ -62,11 +62,11 @@ spec:
       {{- if .Values.nexusProxy.env.nexusHttpHost }}
         - {{ .Values.nexusProxy.env.nexusHttpHost }}
       {{- end }}
+      {{- with .Values.ingress.tls.hosts }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if .Values.ingress.tls.secretName }}
       secretName: {{ .Values.ingress.tls.secretName | quote }}
       {{- end }}
-  {{- with .Values.ingress.tls.hosts }}
-    {{- toYaml . | nindent 4 }}
-  {{- end -}}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
The issue with the current configuration is that we need to define a complete `hosts` block in the value file like for example:
```
ingress:
  tls:
    hosts:
      - hosts:
        - <yourDomain>
        secretName: <yourTlsSecret>
```
More, if you do not use the nexus proxy, it results with an tls block like the following:
```
tls:
  - hosts:
    secretName: "nexus-tls"
  - hosts:
    - <yourDomain>
    secretName: <yourTlsSecret>
```

This PR allows to define the proxy host or the direct host tls configuration in the same block.
I think that if someone need to have the proxy host and the direct host configuration, maybe the chart needs something like a new property named `additionalTls`

Downside: This is a breaking change for those who were specifying the `ingress.tls.hosts` value. I did not change the version in the Chart.yaml as I did not know if it would be a `6.0.0` or something else.

Feel free to tell me if I miss something.