### PR TITLE
chore(sonarqube): update image tag to 8.9.5-community

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.9.0
-appVersion: 8.5.1-community
+version: 9.9.1
+appVersion: 8.9.5-community
 keywords:
   - coverage
   - security

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -20,7 +20,7 @@ OpenShift:
 
 image:
   repository: sonarqube
-  tag: 8.5.1-community
+  tag: 8.9.5-community
   pullPolicy: IfNotPresent
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret


### PR DESCRIPTION
Updates to the latest 8.x community image to mitigate CVE-2021-45046 and CVE-2021-44228 as detailed here: https://community.sonarsource.com/t/sonarqube-sonarcloud-and-the-log4j-vulnerability/54721

Required a DB migration, but everything went without issue as it usually does :) 