### PR TITLE
fix(Ingress/pathType): default to Prefix

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.10.1
+version: 9.10.2
 appVersion: 8.9.7-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -43,9 +43,9 @@ spec:
     - host: {{ .name }}
       http:
         paths:
-          - path: {{ .path}}
+          - path: {{ .path }}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
-            pathType: {{ .pathType }} 
+            pathType: {{ .pathType | default "Prefix" }} 
             {{- end }}
             backend:
               {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}


### PR DESCRIPTION
A previous PR #330  - broke the expected behaviour when applying the chart with only the host and path values set meaning that people now have to set `pathType: Prefix` in all of their values. Setting the value to default to "Prefix" will allow users to avoid the sudden unexpected (and breaking) config change, maintaining the previous behaviour.