### PR TITLE
Add startup probe for sonatype-nexus

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 5.3.6
+version: 5.4.0
 appVersion: 3.37.3
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 5.3.5
+version: 5.3.6
 appVersion: 3.37.3
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/charts/sonatype-nexus/README.md
+++ b/charts/sonatype-nexus/README.md
@@ -110,6 +110,11 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.failureThreshold`     | Number of attempts before failure   | 6                                       |
 | `nexus.readinessProbe.timeoutSeconds`       | Time in seconds after readiness probe times out    | `nil`                    |
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
+| `nexus.startupProbe.initialDelaySeconds`    | StartupProbe initial delay          | 30                                      |
+| `nexus.startupProbe.periodSeconds`          | Seconds between polls               | 30                                      |
+| `nexus.startupProbe.failureThreshold`       | Number of attempts before failure   | 6                                       |
+| `nexus.startupProbe.timeoutSeconds`         | Time in seconds after startup probe times out    | `nil`                     |
+| `nexus.startupProbe.path`                   | Path for StartupProbe              | /                                       |
 | `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
 | `nexus.context`                             | Non-root path to run Nexus at       | `nil`                                   |
 | `nexus.chownNexusData`                      | Set false to not execute chown to the mounted nexus-data directory at startup | `true` |

--- a/charts/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/charts/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -128,6 +128,18 @@ spec:
             {{- if .Values.nexus.readinessProbe.timeoutSeconds }}
             timeoutSeconds: {{ .Values.nexus.readinessProbe.timeoutSeconds }}
             {{- end }}
+          {{- if .Values.nexus.startupProbe }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.nexus.startupProbe.path }}
+              port: {{ .Values.nexus.nexusPort }}
+            initialDelaySeconds: {{ .Values.nexus.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.nexus.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.nexus.startupProbe.failureThreshold }}
+            {{- if .Values.nexus.startupProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.nexus.startupProbe.timeoutSeconds }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - mountPath: /nexus-data
               name: {{ template "nexus.fullname" . }}-data

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -83,6 +83,12 @@ nexus:
     failureThreshold: 6
     # timeoutSeconds: 10
     path: /
+  # startupProbe:
+  #   initialDelaySeconds: 10
+  #   periodSeconds: 10
+  #   failureThreshold: 300
+  #   # timeoutSeconds: 10
+  #   path: /
   # hostAliases allows the modification of the hosts file inside a container
   hostAliases: []
   # - ip: "192.168.1.10"


### PR DESCRIPTION
Add a `startupProbe` for nexus.

Nexus can take a lot of time to start, especially when big volumes are mounted, so we can add a startup probe to avoid long delay on `liveness` and `readiness` probe in case of a restart.