### PR TITLE
Bumping sonatype-nexus version

### DIFF
--- a/charts/sonatype-nexus/Chart.yaml
+++ b/charts/sonatype-nexus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonatype-nexus
-version: 5.4.0
-appVersion: 3.37.3
+version: 5.4.1
+appVersion: 3.38.1
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - artifacts

--- a/charts/sonatype-nexus/values.yaml
+++ b/charts/sonatype-nexus/values.yaml
@@ -20,7 +20,7 @@ initAdminPassword:
 
 nexus:
   imageName: quay.io/travelaudience/docker-nexus
-  imageTag: 3.37.3-02
+  imageTag: 3.38.1-01
   imagePullPolicy: IfNotPresent
   # Uncomment this to scheduler pods on priority
   # priorityClassName: "high-priority"


### PR DESCRIPTION
Simply bumping up to the newest version of sonatype-nexus as 3.38.x fixes an HTML injection attack and enables a Log4JVisualizer chart.