### PR TITLE
[SonarQube] Security enhancement - Disable Service Account Token Automount

### DIFF
--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.10.3
+version: 9.10.4
 appVersion: 8.9.7-community
 keywords:
   - coverage

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sonarqube
 description: SonarQube is an open sourced code quality scanning tool
-version: 9.10.4
+version: 9.11.0
 appVersion: 8.9.7-community
 keywords:
   - coverage

--- a/charts/sonarqube/templates/serviceaccount.yaml
+++ b/charts/sonarqube/templates/serviceaccount.yaml
@@ -12,4 +12,5 @@ metadata:
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -347,6 +347,8 @@ serviceAccount:
   # name:
   ## Annotations for the Service Account
   annotations: {}
+  # Disable the automouting of the Service Account Token into the pod filesystem.
+  automountServiceAccountToken: false
 
 # extraConfig is used to load Environment Variables from Secrets and ConfigMaps
 # which may have been written by other tools, such as external orchestrators.


### PR DESCRIPTION
Disable the automounting of the Service Account Token into the pod filesystem.
Source: https://securecloud.blog/2021/08/17/azure-aks-reviewing-recommendations-from-security-center-disabling-automounting-api-credentials/