### PR TITLE
Add SONAR_WEB_CONTEXT example in comments

### DIFF
--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -204,6 +204,9 @@ jvmOpts: ""
 ## Environment variables to attach to the pods
 ##
 # env:
+#   # If you use a different ingress path from /, you have to add it here as the value of SONAR_WEB_CONTEXT
+#   - name: SONAR_WEB_CONTEXT
+#     value: /sonarqube
 #   - name: VARIABLE
 #     value: my-value
 


### PR DESCRIPTION
Without setting SONAR_WEB_CONTEXT, using a non-default path doesn't work.

Fixes this issue:
https://github.com/SonarSource/helm-chart-sonarqube/issues/205